### PR TITLE
antsImageClone on multi-component images

### DIFF
--- a/R/antsImageClone.R
+++ b/R/antsImageClone.R
@@ -34,6 +34,4 @@ antsImageClone <- function(in_image, out_pixeltype = in_image@pixeltype) {
   }
   
   .Call("antsImageClone", in_image, out_pixeltype, PACKAGE = "ANTsRCore")
-  
 }
-

--- a/R/antsImageClone.R
+++ b/R/antsImageClone.R
@@ -21,5 +21,19 @@ antsImageClone <- function(in_image, out_pixeltype = in_image@pixeltype) {
   if (length(dim(in_image)) == 1)
     if (dim(in_image)[1] == 1)
       return(NULL)
+  
+  if (in_image@components > 1) 
+  {
+    mychanns <- splitChannels( in_image )
+    for ( k in 1:length(mychanns) )
+    {
+      img.clone <- .Call("antsImageClone", mychanns[[k]], out_pixeltype, PACKAGE = "ANTsRCore")
+      mychanns[[k]] <- img.clone
+    }
+    return( mergeChannels( mychanns ) )
+  }
+  
   .Call("antsImageClone", in_image, out_pixeltype, PACKAGE = "ANTsRCore")
+  
 }
+


### PR DESCRIPTION
Fixes issue where `antsImageClone` drops components on multi-component images

Coding style for splitChannels/mergeChannels was taken from [resampleImage.R](https://github.com/ANTsX/ANTsRCore/blob/master/R/resampleImage.R#L43-L53).

Feel free to change anything


Example fix:
```R
fi <- antsImageRead(getANTsRData("r16") )
mi <- antsImageRead(getANTsRData("r64") )
fi<-resampleImage(fi,c(60,60),1,0)
mi<-resampleImage(mi,c(60,60),1,0) # speed up
mytx <- antsRegistration(fixed=fi, moving=mi, typeofTransform = c('SyN') )
compfield <- composeTransformsToField( fi, mytx$fwd ) # has two components
# clone
compfield2 <- antsImageClone(compfield)

# should be the same
print(sum(compfield - compfield2))
```