### PR TITLE
ENH: transform matrices of points and vectors

### DIFF
--- a/R/antsrTransform_class.R
+++ b/R/antsrTransform_class.R
@@ -245,21 +245,39 @@ applyAntsrTransform <- function(transform, data, dataType="point", reference=NA,
     return( applyAntsrTransformToImage( transform, data, reference, ...) )
   }
   else {
+    ismatrix=TRUE
+    if (class(data)=="numeric") {
+      data = t(as.matrix(data))
+      ismatrix = FALSE
+    }
+
+    ret=NA
     if ( dataType == "point") {
-      return( applyAntsrTransformToPoint(transform, data))
+      ret = applyAntsrTransformToPoint(transform, data)
     }
     else if ( dataType == "vector") {
-      return( applyAntsrTransformToVector(transform, data))
+      ret = applyAntsrTransformToVector(transform, data)
     }
+    else {
+      stop("Invalid datatype")
+    }
+
+    if ( !ismatrix ) {
+      ret = as.numeric(t(ret))
+    }
+
+    return(ret)
+
   }
 
-  stop("Unsupported input data type")
+  # Never reached
+  return(NA)
 }
 
 #' @title applyAntsrTransformToPoint
 #' @description Apply transform to spatial point
 #' @param transform antsrTransform
-#' @param point a spatial point
+#' @param points a matrix which each row is a spatial point
 #' @return array of coordinates
 #' @examples
 #' tx = new("antsrTransform")
@@ -267,23 +285,46 @@ applyAntsrTransform <- function(transform, data, dataType="point", reference=NA,
 #' setAntsrTransformParameters(tx, params*2)
 #' pt2 = applyAntsrTransformToPoint(tx, c(1,2,3))
 #' @export
-applyAntsrTransformToPoint <- function(transform, point) {
-  return(.Call("antsrTransform_TransformPoint", transform, point, PACKAGE = "ANTsRCore"))
+applyAntsrTransformToPoint <- function(transform, points) {
+
+  ismatrix=TRUE
+  if (class(points)=="numeric") {
+    points = t(as.matrix(points))
+    ismatrix = FALSE
+  }
+
+  ret = .Call("antsrTransform_TransformPoint", transform, points, PACKAGE = "ANTsRCore")
+
+  if ( !ismatrix ) {
+    ret = as.numeric(t(ret))
+  }
+
+  return(ret)
 }
 
 #' @title applyAntsrTransformToVector
 #' @description Apply transform to spatial vector
 #' @param transform antsrTransform
-#' @param vector array of vector coordinates
+#' @param vectors a matrix where each row is a vector to transform
 #' @return array of coordinates
 #' @examples
 #' \dontrun{
 #' vec2 = applyAntsrTransformToVector(transform, c(1,2,3))
 #' }
 #' @export
-applyAntsrTransformToVector <- function(transform, vector) {
-  return(.Call("antsrTransform_TransformVector", transform,
-               vector, PACKAGE = "ANTsRCore"))
+applyAntsrTransformToVector <- function(transform, vectors) {
+
+  ismatrix=TRUE
+  if (class(vectors)=="numeric") {
+    vectors = t(as.matrix(vectors))
+    ismatrix = FALSE
+  }
+  ret = .Call("antsrTransform_TransformVector", transform, vectors, PACKAGE = "ANTsRCore")
+
+  if ( !ismatrix ) {
+    ret = as.numeric(t(ret))
+  }
+  return(ret)
 }
 
 #' @title applyAntsrTransformToImage

--- a/man/applyAntsrTransformToPoint.Rd
+++ b/man/applyAntsrTransformToPoint.Rd
@@ -4,12 +4,12 @@
 \alias{applyAntsrTransformToPoint}
 \title{applyAntsrTransformToPoint}
 \usage{
-applyAntsrTransformToPoint(transform, point)
+applyAntsrTransformToPoint(transform, points)
 }
 \arguments{
 \item{transform}{antsrTransform}
 
-\item{point}{a spatial point}
+\item{points}{a matrix which each row is a spatial point}
 }
 \value{
 array of coordinates

--- a/man/applyAntsrTransformToVector.Rd
+++ b/man/applyAntsrTransformToVector.Rd
@@ -4,12 +4,12 @@
 \alias{applyAntsrTransformToVector}
 \title{applyAntsrTransformToVector}
 \usage{
-applyAntsrTransformToVector(transform, vector)
+applyAntsrTransformToVector(transform, vectors)
 }
 \arguments{
 \item{transform}{antsrTransform}
 
-\item{vector}{array of vector coordinates}
+\item{vectors}{a matrix where each row is a vector to transform}
 }
 \value{
 array of coordinates

--- a/src/antsrTransform.cpp
+++ b/src/antsrTransform.cpp
@@ -809,7 +809,6 @@ return Rcpp::wrap(NA_REAL); //not reached
 template< class PrecisionType, unsigned int Dimension >
 SEXP antsrTransform_TransformPoint( SEXP r_transform, SEXP r_point )
 {
-
   Rcpp::S4 transform( r_transform );
   std::string type = Rcpp::as<std::string>( transform.slot("type") );
 
@@ -819,23 +818,27 @@ SEXP antsrTransform_TransformPoint( SEXP r_transform, SEXP r_point )
   typedef typename TransformType::OutputPointType  OutputPointType;
 
   TransformPointerType itkTransform = Rcpp::as<TransformPointerType>( r_transform );
-  Rcpp::NumericVector inPoint( r_point );
 
-  InputPointType inItkPoint;
-  for (unsigned int i=0; i<InputPointType::PointDimension; i++)
-    {
-    inItkPoint[i] = inPoint[i];
+  Rcpp::NumericMatrix inPoints( r_point );
+  Rcpp::NumericMatrix outPoints( inPoints.nrow(), inPoints.ncol() );
+
+  for (unsigned int n=0; n<inPoints.nrow(); n++) {
+
+    InputPointType inItkPoint;
+    for (unsigned int i=0; i<InputPointType::PointDimension; i++)
+      {
+      inItkPoint[i] = inPoints(n,i);
+      }
+
+    OutputPointType outItkPoint = itkTransform->TransformPoint( inItkPoint );
+
+    for (unsigned int i=0; i<OutputPointType::PointDimension; i++)
+      {
+      outPoints(n,i) = outItkPoint[i];
+      }
     }
 
-OutputPointType outItkPoint = itkTransform->TransformPoint( inItkPoint );
-
-  Rcpp::NumericVector outPoint( OutputPointType::PointDimension );
-  for (unsigned int i=0; i<OutputPointType::PointDimension; i++)
-    {
-    outPoint[i] = outItkPoint[i];
-    }
-
-  return outPoint;
+  return Rcpp::wrap(outPoints);
 }
 
 
@@ -926,23 +929,25 @@ SEXP antsrTransform_TransformVector( SEXP r_transform, SEXP r_vector )
 
 
   TransformPointerType itkTransform = Rcpp::as<TransformPointerType>( r_transform );
-  Rcpp::NumericVector inVector( r_vector );
+  Rcpp::NumericMatrix inVectors( r_vector );
+  Rcpp::NumericMatrix outVectors( inVectors.nrow(), inVectors.ncol() );
 
-  InputVectorType inItkVector;
-  for (unsigned int i=0; i<InputVectorType::Dimension; i++)
-    {
-    inItkVector[i] = inVector[i];
+  for (unsigned int n=0; n<inVectors.nrow(); n++ ) {
+    InputVectorType inItkVector;
+    for (unsigned int i=0; i<InputVectorType::Dimension; i++)
+      {
+      inItkVector[i] = inVectors(n,i);
+      }
+
+    OutputVectorType outItkVector = itkTransform->TransformVector( inItkVector );
+
+    for (unsigned int i=0; i<OutputVectorType::Dimension; i++)
+      {
+      outVectors(n,i) = outItkVector[i];
+      }
     }
 
-  OutputVectorType outItkVector = itkTransform->TransformVector( inItkVector );
-
-  Rcpp::NumericVector outVector( OutputVectorType::Dimension );
-  for (unsigned int i=0; i<OutputVectorType::Dimension; i++)
-    {
-    outVector[i] = outItkVector[i];
-    }
-
-  return outVector;
+  return Rcpp::wrap(outVectors);
 }
 
 


### PR DESCRIPTION
A small update to the antsrTransform class so that it may be used to apply a transform to a matrix of points or vectors, instead of just single points or vectors.