### PR TITLE
Fixed an rscript error

### DIFF
--- a/configure
+++ b/configure
@@ -7,16 +7,16 @@ compflags=`${R_HOME}/bin/Rscript -e 'a<-ITKR:::itkCompileFlags(); cat(a)'`
 ITKDIR=`${R_HOME}/bin/Rscript -e 'a<-ITKR:::itkDir(); cat(a)'`
 
 # get a version of cmake
-cmaker=`Rscript -e "x=Sys.which('cmake'); cat(x)"`
+cmaker=`${R_HOME}/bin/Rscript -e "x=Sys.which('cmake'); cat(x)"`
 if [[ -z "${cmaker}" ]]; then
-	res=`Rscript -e "cat(('cmaker' %in% installed.packages())*1)"`
+	res=`${R_HOME}/bin/Rscript -e "cat(('cmaker' %in% installed.packages())*1)"`
 	if [[ $res -eq 0 ]];
 		then
 	    git clone https://github.com/stnava/cmaker ;
 	    R CMD INSTALL cmaker ;
 	    rm -rf cmaker ;
 	fi
-    cmaker=`Rscript -e "x=cmaker::cmake()"`
+    cmaker=`${R_HOME}/bin/Rscript -e "x=cmaker::cmake()"`
 else
 	cmaker="cmake"
 fi


### PR DESCRIPTION
As per this error: http://r.789695.n4.nabble.com/Error-message-Rscript-should-not-be-used-without-a-path-td4748071.html you have to specify full path for `Rscript` in `Makefile`/`configure`.  This will start failing with R 3.5.0 using `R CMD check`.