### PR TITLE
FIX: return NA on Joint PDF summed to zero

### DIFF
--- a/src/antsrMetric.cpp
+++ b/src/antsrMetric.cpp
@@ -530,7 +530,8 @@ catch( itk::ExceptionObject & err )
   {
   Rcpp::Rcout << "ITK ExceptionObject caught !" << std::endl;
   Rcpp::Rcout << err << std::endl;
-  Rcpp::stop("ITK exception caught");
+  return Rcpp::wrap(NA_REAL);
+  //Rcpp::stop("ITK exception caught");
   }
 catch( const std::exception& exc )
   {


### PR DESCRIPTION
modified to return NA when the Joint PDF sums to zero, exception is still printed.