### PR TITLE
Fix for broken image IO

### DIFF
--- a/src/antsImageHeaderInfo.cpp
+++ b/src/antsImageHeaderInfo.cpp
@@ -48,37 +48,40 @@ try
 
   switch( pixelCode )
     {
-    case 0: // UNKNOWNCOMPONENTTYPE - exception here?
+    case itk::ImageIOBase::IOComponentType::UNKNOWNCOMPONENTTYPE: // UNKNOWNCOMPONENTTYPE - exception here?
       pixeltype = "unknown";
       break;
-    case 1: // UCHAR
+    case itk::ImageIOBase::IOComponentType::UCHAR: // UCHAR
       pixeltype = "unsigned char";
       break;
-    case 2: // CHAR
+    case itk::ImageIOBase::IOComponentType::CHAR: // CHAR
       pixeltype = "char";
       break;
-    case 3: // USHORT
+    case itk::ImageIOBase::IOComponentType::USHORT: // USHORT
       pixeltype = "unsigned short";
       break;
-    case 4: // SHORT
+    case itk::ImageIOBase::IOComponentType::SHORT: // SHORT
       pixeltype = "short";
       break;
-    case 5: // UINT
+    case itk::ImageIOBase::IOComponentType::UINT: // UINT
       pixeltype = "unsigned int";
       break;
-    case 6: // INT
+    case itk::ImageIOBase::IOComponentType::INT: // INT
       pixeltype = "int";
       break;
-    case 7: // ULONG
+    case itk::ImageIOBase::IOComponentType::ULONG: // ULONG
       pixeltype = "unsigned long";
       break;
-    case 8: // LONG
+    case itk::ImageIOBase::IOComponentType::LONG: // LONG
       pixeltype = "long";
       break;
-    case 9: // FLOAT
+    case itk::ImageIOBase::IOComponentType::LONGLONG: // LONG
+      pixeltype = "longlong";
+      break;
+    case itk::ImageIOBase::IOComponentType::FLOAT: // FLOAT
       pixeltype = "float";
       break;
-    case 10: // DOUBLE
+    case itk::ImageIOBase::IOComponentType::DOUBLE: // DOUBLE
       pixeltype = "double";
       break;
     default:

--- a/src/antsImageHeaderInfo.cpp
+++ b/src/antsImageHeaderInfo.cpp
@@ -75,7 +75,7 @@ try
     case itk::ImageIOBase::IOComponentType::LONG: // LONG
       pixeltype = "long";
       break;
-    case itk::ImageIOBase::IOComponentType::LONGLONG: // LONG
+    case itk::ImageIOBase::IOComponentType::LONGLONG: // LONGLONG
       pixeltype = "longlong";
       break;
     case itk::ImageIOBase::IOComponentType::FLOAT: // FLOAT

--- a/src/antsImageHeaderInfo.cpp
+++ b/src/antsImageHeaderInfo.cpp
@@ -75,6 +75,9 @@ try
     case itk::ImageIOBase::IOComponentType::LONG: // LONG
       pixeltype = "long";
       break;
+    case itk::ImageIOBase::IOComponentType::ULONGLONG: // LONGLONG
+      pixeltype = "ulonglong";
+      break;
     case itk::ImageIOBase::IOComponentType::LONGLONG: // LONGLONG
       pixeltype = "longlong";
       break;


### PR DESCRIPTION
the itkImageIOBase class added a data type (longlong) which was inserted into the IOComponentType enum. This broke IO in ANTsRCore for some types due to the use of hard coded values instead of the enum type to identify data types.  This resolves the issue and helps "future-proof" the IO by using the enums instead of hard coded values.