### PR TITLE
Removing warning checks to speed up math operations

### DIFF
--- a/R/zzz_Summary.R
+++ b/R/zzz_Summary.R
@@ -51,9 +51,9 @@ setMethod("Summary", "antsImage",
             x = mask_values(x, mask)
             # I think this makes sense but should ask Avants.
             # relevant for warnings for all/any in summary
-            if (all(x %in% c(0, 1, NA, NaN))) {
-              x = as.logical(x)
-            }
+            # if (all(x %in% c(0, 1, NA, NaN))) {
+            #   x = as.logical(x)
+            # }
             args$x = x
             args$na.rm = na.rm
             


### PR DESCRIPTION
Looks like this improves performance, but still `sum(as.array(img))` is about 30% faster than `sum(img)`, so maybe we can try other improvements as well. 