### PR TITLE
Moved getValueatPoint to ANTsR

### DIFF
--- a/R/antsTransformPoints.R
+++ b/R/antsTransformPoints.R
@@ -1,32 +1,3 @@
-
-
-# .getValueAtPoint <- function(x, point) {
-#   if (class(x)[1] != "antsImage") {
-#     stop("Input must be of class 'antsImage'")
-#   }
-#   if ((class(point) != "numeric")) {
-#     stop("point must be of class 'numeric'")
-#   }
-#   
-#   idx <- as.numeric(antsTransformPhysicalPointToIndex(x, point))
-#   idx <- floor(idx)
-#   
-#   dims <- length(idx)
-#   
-#   value <- NA
-#   if (dims == 2) {
-#     value <- getPixels(x, i = idx[1], j = idx[2])
-#   } else if (dims == 3) {
-#     value <- getPixels(x, i = idx[1], j = idx[2], k = idx[3])
-#   } else if (dims == 4) {
-#     value <- getPixels(x, i = idx[1], j = idx[2], k = idx[3], l = idx[4])
-#   }
-#   
-#   return(value[[1]])
-#   
-# }
-
-
 #' Get Spatial Point from Index
 #'
 #' Get spatial point from index of an \code{antsImage}.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,7 +73,6 @@ build_script:
   # - set PATH=%PATH%;C:\Program Files\7-Zip
   - travis-tool.sh install_deps
 
-
 test_script:
   - R CMD INSTALL --build --no-multiarch .
   # - travis-tool.sh run_tests

--- a/configure.win
+++ b/configure.win
@@ -106,12 +106,13 @@ fi
 
 echo ${cmaker}
 
+
 ${cmaker} \
     -G "MinGW Makefiles" \
     -DITK_DIR:PATH="${ITKDIR}" \
     -DCMAKE_SH:BOOL=OFF \
-    -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} ${CMAKE_EXE_LINKER_FLAGS} ${compflags} -DNDEBUG -D_FILE_OFFSET_BITS=64"\
-    -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} ${compflags} -DNDEBUG  "\
+    -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -Wa,-mbig-obj ${CMAKE_EXE_LINKER_FLAGS} ${compflags} -DNDEBUG -D_FILE_OFFSET_BITS=64"\
+    -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -Wa,-mbig-obj ${compflags} -DNDEBUG  "\
     -DBUILD_SHARED_LIBS=ON \
     -DBUILD_ALL_ANTS_APPS=OFF \
     -DUSE_SYSTEM_ITK=OFF \


### PR DESCRIPTION
getValueatPoint was never used in ANTsRCore, so moved to ANTsR as it was needed there and shouldn't be called using :::