### PR TITLE
antsImageHeaderInfo fixes (inc segfault protection)

### DIFF
--- a/R/antsImageHeaderInfo.R
+++ b/R/antsImageHeaderInfo.R
@@ -32,6 +32,8 @@ antsImageHeaderInfo <- function( filename )
     tfile = tempfile(fileext = ".nii.gz")
     antsImageWrite(filename, tfile)
     filename = tfile
+  } else {
+    filename = path.expand(filename)
   }
   if ( !file.exists(filename) )
   {

--- a/R/antsImageHeaderInfo.R
+++ b/R/antsImageHeaderInfo.R
@@ -31,6 +31,7 @@ antsImageHeaderInfo <- function( filename )
   if (is.antsImage(filename)) {
     tfile = tempfile(fileext = ".nii.gz")
     antsImageWrite(filename, tfile)
+    on.exit(unlink(tfile))
     filename = tfile
   } else {
     filename = path.expand(filename)


### PR DESCRIPTION
Currently, if you try to get header information for an image using a path like so
```
antsImageHeaderInfo("~/projects/myimage.nii.gz")
```
you will get a segfault.

Also clean up temp file if one was required.
