### PR TITLE
FIX: write DTI with correct intent code

### DIFF
--- a/R/antsImageWrite.R
+++ b/R/antsImageWrite.R
@@ -5,6 +5,7 @@
 #'
 #' @param image Image object of S4 class \code{antsImage} to be written.
 #' @param filename Name of the file to write the image to.
+#' @param as.tensor flag indicating to write as symmetric tensor if image has 6 components
 #' @return 0 -- Success\cr 1 -- Failure
 #' @author Shrinidhi KL
 #' @seealso \code{\link{antsImageRead}}
@@ -26,13 +27,13 @@
 #' components(fi) = -1L
 #' testthat::expect_error(
 #' antsImageWrite( fi, tempfile( fileext = ".nii.gz" )), "nvalid S4"
-#' )  
+#' )
 #' testthat::expect_error(
 #' antsImageWrite( "hey"), "not exist"
-#' ) 
+#' )
 #'
 #' @export antsImageWrite
-antsImageWrite <- function(image, filename) {
+antsImageWrite <- function(image, filename, as.tensor=FALSE) {
   image = check_ants(image)
   if (class(image) != "antsImage") {
     stop("'image' argument provided is not of class antsImage")
@@ -43,5 +44,5 @@ antsImageWrite <- function(image, filename) {
     image@components = as.integer(1)
     }
   filename <- path.expand(filename)
-  invisible(.Call("antsImageWrite", image, filename, PACKAGE = "ANTsRCore"))
+  invisible(.Call("antsImageWrite", image, filename, as.tensor, PACKAGE = "ANTsRCore"))
 }

--- a/man/antsImageWrite.Rd
+++ b/man/antsImageWrite.Rd
@@ -4,12 +4,14 @@
 \alias{antsImageWrite}
 \title{Image Write}
 \usage{
-antsImageWrite(image, filename)
+antsImageWrite(image, filename, as.tensor = FALSE)
 }
 \arguments{
 \item{image}{Image object of S4 class \code{antsImage} to be written.}
 
 \item{filename}{Name of the file to write the image to.}
+
+\item{as.tensor}{flag indicating to write as symmetric tensor if image has 6 components}
 }
 \value{
 0 -- Success\cr 1 -- Failure
@@ -35,10 +37,10 @@ antsImageWrite( fi, tempfile( fileext = ".nii.gz" )  )
 components(fi) = -1L
 testthat::expect_error(
 antsImageWrite( fi, tempfile( fileext = ".nii.gz" )), "nvalid S4"
-)  
+)
 testthat::expect_error(
 antsImageWrite( "hey"), "not exist"
-) 
+)
 
 }
 \seealso{

--- a/src/init.c
+++ b/src/init.c
@@ -12,7 +12,7 @@
   This needs to be resolved in the tables and any declarations.
 */
 
-/* FIXME: 
+/* FIXME:
    Check these declarations against the C/Fortran source code.
 */
 
@@ -62,7 +62,7 @@ extern SEXP antsImageLogicImageNumeric(SEXP, SEXP, SEXP);
 extern SEXP antsImageMath(SEXP, SEXP);
 extern SEXP antsImageMutualInformation(SEXP, SEXP);
 extern SEXP antsImageRead(SEXP, SEXP, SEXP, SEXP);
-extern SEXP antsImageWrite(SEXP, SEXP);
+extern SEXP antsImageWrite(SEXP, SEXP, SEXP);
 extern SEXP antsJointFusion(SEXP);
 extern SEXP antsMatrix(SEXP);
 extern SEXP antsMatrix_asantsMatrix(SEXP, SEXP);
@@ -158,7 +158,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"antsImageMath",                           (DL_FUNC) &antsImageMath,                            2},
     {"antsImageMutualInformation",              (DL_FUNC) &antsImageMutualInformation,               2},
     {"antsImageRead",                           (DL_FUNC) &antsImageRead,                            4},
-    {"antsImageWrite",                          (DL_FUNC) &antsImageWrite,                           2},
+    {"antsImageWrite",                          (DL_FUNC) &antsImageWrite,                           3},
     {"antsJointFusion",                         (DL_FUNC) &antsJointFusion,                          1},
     {"antsMatrix",                              (DL_FUNC) &antsMatrix,                               1},
     {"antsMatrix_asantsMatrix",                 (DL_FUNC) &antsMatrix_asantsMatrix,                  2},


### PR DESCRIPTION
This update allows for the option of telling antsImageWrite that the input image is a diffusion tensor image, so that when saved as nifti, the correct intent code and element ordering will be used. 