### PR TITLE
FIX: use modified image info correctly

### DIFF
--- a/src/antsImageWrite.cpp
+++ b/src/antsImageWrite.cpp
@@ -23,6 +23,7 @@ namespace ants
     typename ImageWriterType::Pointer image_writer = ImageWriterType::New() ;
     image_writer->SetFileName( filename.c_str() ) ;
     image_writer->SetInput( image );
+    image_writer->SetUseInputMetaDataDictionary(false);
     image_writer->Update();
     return 0;
   }


### PR DESCRIPTION
Resolve issue where images are written using the meta info from the original file, instead of using info that changed via antsSet*() methods.

A resolution to issue  #75 
