### PR TITLE
FIX: remove name collisions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.tgz
 ..Rcheck/
+.vscode/
 
 docs
 /src/*.o

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -94,16 +94,16 @@ ThresholdImage <- function(r_args) {
     .Call(`_ANTsRCore_ThresholdImage`, r_args)
 }
 
-antsAffineInitializer <- function(r_args) {
-    .Call(`_ANTsRCore_antsAffineInitializer`, r_args)
+AntsAffineInitializer <- function(r_args) {
+    .Call(`_ANTsRCore_AntsAffineInitializer`, r_args)
 }
 
-antsApplyTransforms <- function(r_args) {
-    .Call(`_ANTsRCore_antsApplyTransforms`, r_args)
+AntsApplyTransforms <- function(r_args) {
+    .Call(`_ANTsRCore_AntsApplyTransforms`, r_args)
 }
 
-antsApplyTransformsToPoints <- function(r_args) {
-    .Call(`_ANTsRCore_antsApplyTransformsToPoints`, r_args)
+AntsApplyTransformsToPoints <- function(r_args) {
+    .Call(`_ANTsRCore_AntsApplyTransformsToPoints`, r_args)
 }
 
 antsImage <- function(r_pixeltype, r_dimension, r_components) {
@@ -202,8 +202,8 @@ antsImageArithImageImage <- function(r_antsimage1, r_antsimage2, r_operator) {
     .Call(`_ANTsRCore_antsImageArithImageImage`, r_antsimage1, r_antsimage2, r_operator)
 }
 
-antsImageClone <- function(r_in_image, r_out_pixeltype) {
-    .Call(`_ANTsRCore_antsImageClone`, r_in_image, r_out_pixeltype)
+AntsImageClone <- function(r_in_image, r_out_pixeltype) {
+    .Call(`_ANTsRCore_AntsImageClone`, r_in_image, r_out_pixeltype)
 }
 
 antsImageComparisonImageNumeric <- function(r_antsimage, r_numeric, r_operator) {
@@ -214,12 +214,12 @@ antsImageComparisonImageImage <- function(r_antsimage1, r_antsimage2, r_operator
     .Call(`_ANTsRCore_antsImageComparisonImageImage`, r_antsimage1, r_antsimage2, r_operator)
 }
 
-antsImageHeaderInfo <- function(r_filename) {
-    .Call(`_ANTsRCore_antsImageHeaderInfo`, r_filename)
+AntsImageHeaderInfo <- function(r_filename) {
+    .Call(`_ANTsRCore_AntsImageHeaderInfo`, r_filename)
 }
 
-antsImageIterator <- function(r_antsimage) {
-    .Call(`_ANTsRCore_antsImageIterator`, r_antsimage)
+AntsImageIterator <- function(r_antsimage) {
+    .Call(`_ANTsRCore_AntsImageIterator`, r_antsimage)
 }
 
 antsImageIterator_Get <- function(r_antsimageiterator) {
@@ -282,16 +282,16 @@ antsImageMutualInformation <- function(r_in_image1, r_in_image2) {
     .Call(`_ANTsRCore_antsImageMutualInformation`, r_in_image1, r_in_image2)
 }
 
-antsImageRead <- function(r_filename, r_pixeltype, r_dimension, r_components) {
-    .Call(`_ANTsRCore_antsImageRead`, r_filename, r_pixeltype, r_dimension, r_components)
+AntsImageRead <- function(r_filename, r_pixeltype, r_dimension, r_components) {
+    .Call(`_ANTsRCore_AntsImageRead`, r_filename, r_pixeltype, r_dimension, r_components)
 }
 
-antsImageStats <- function(r_antsimage, r_mask, r_narm) {
-    .Call(`_ANTsRCore_antsImageStats`, r_antsimage, r_mask, r_narm)
+AntsImageStats <- function(r_antsimage, r_mask, r_narm) {
+    .Call(`_ANTsRCore_AntsImageStats`, r_antsimage, r_mask, r_narm)
 }
 
-antsImageWrite <- function(r_img, r_filename, r_asTensor) {
-    .Call(`_ANTsRCore_antsImageWrite`, r_img, r_filename, r_asTensor)
+AntsImageWrite <- function(r_img, r_filename, r_asTensor) {
+    .Call(`_ANTsRCore_AntsImageWrite`, r_img, r_filename, r_asTensor)
 }
 
 antsJointFusion <- function(r_args) {
@@ -310,16 +310,16 @@ antsMatrix_asantsMatrix <- function(r_list, r_elementtype) {
     .Call(`_ANTsRCore_antsMatrix_asantsMatrix`, r_list, r_elementtype)
 }
 
-antsMotionCorr <- function(r_args) {
-    .Call(`_ANTsRCore_antsMotionCorr`, r_args)
+AntsMotionCorr <- function(r_args) {
+    .Call(`_ANTsRCore_AntsMotionCorr`, r_args)
 }
 
 antsMotionCorrStats <- function(r_tsimg, r_mask, r_moco, r_stupidoffset) {
     .Call(`_ANTsRCore_antsMotionCorrStats`, r_tsimg, r_mask, r_moco, r_stupidoffset)
 }
 
-antsRegistration <- function(r_args) {
-    .Call(`_ANTsRCore_antsRegistration`, r_args)
+AntsRegistration <- function(r_args) {
+    .Call(`_ANTsRCore_AntsRegistration`, r_args)
 }
 
 antsrMetric <- function(r_pixeltype, r_dimension, r_type, r_isVector, r_fixed, r_moving) {
@@ -418,20 +418,20 @@ antsrTransform_Write <- function(r_transform, filename_) {
     .Call(`_ANTsRCore_antsrTransform_Write`, r_transform, filename_)
 }
 
-cropImage <- function(r_in_image1, r_in_image2, r_label, r_decrop, r_loind, r_upind) {
-    .Call(`_ANTsRCore_cropImage`, r_in_image1, r_in_image2, r_label, r_decrop, r_loind, r_upind)
+CropImage <- function(r_in_image1, r_in_image2, r_label, r_decrop, r_loind, r_upind) {
+    .Call(`_ANTsRCore_CropImage`, r_in_image1, r_in_image2, r_label, r_decrop, r_loind, r_upind)
 }
 
-extractSlice <- function(r_in_image1, r_slice, r_direction, r_collapseStrategy) {
-    .Call(`_ANTsRCore_extractSlice`, r_in_image1, r_slice, r_direction, r_collapseStrategy)
+ExtractSlice <- function(r_in_image1, r_slice, r_direction, r_collapseStrategy) {
+    .Call(`_ANTsRCore_ExtractSlice`, r_in_image1, r_slice, r_direction, r_collapseStrategy)
 }
 
 fastMarchingExtension <- function(r_speedImage, r_labelImage, r_valueImage) {
     .Call(`_ANTsRCore_fastMarchingExtension`, r_speedImage, r_labelImage, r_valueImage)
 }
 
-fsl2antsrTransform <- function(r_matrix, r_reference, r_moving, r_flag) {
-    .Call(`_ANTsRCore_fsl2antsrTransform`, r_matrix, r_reference, r_moving, r_flag)
+fsl2antsrTransformR <- function(r_matrix, r_reference, r_moving, r_flag) {
+    .Call(`_ANTsRCore_fsl2antsrTransformR`, r_matrix, r_reference, r_moving, r_flag)
 }
 
 iMathInterface <- function(r_args) {
@@ -458,16 +458,16 @@ itkConvolveImage <- function(r_in_image1, r_in_image2) {
     .Call(`_ANTsRCore_itkConvolveImage`, r_in_image1, r_in_image2)
 }
 
-labelStats <- function(r_image, r_labelImage) {
-    .Call(`_ANTsRCore_labelStats`, r_image, r_labelImage)
+labelStatsR <- function(r_image, r_labelImage) {
+    .Call(`_ANTsRCore_labelStatsR`, r_image, r_labelImage)
 }
 
-makeImage <- function(r_pixeltype, r_size, r_spacing, r_origin, r_direction, r_components) {
-    .Call(`_ANTsRCore_makeImage`, r_pixeltype, r_size, r_spacing, r_origin, r_direction, r_components)
+makeImageR <- function(r_pixeltype, r_size, r_spacing, r_origin, r_direction, r_components) {
+    .Call(`_ANTsRCore_makeImageR`, r_pixeltype, r_size, r_spacing, r_origin, r_direction, r_components)
 }
 
-mergeChannels <- function(r_imageList) {
-    .Call(`_ANTsRCore_mergeChannels`, r_imageList)
+mergeChannelsR <- function(r_imageList) {
+    .Call(`_ANTsRCore_mergeChannelsR`, r_imageList)
 }
 
 blobAnalysis <- function(r_inimg, r_outimg, r_numberOfBlobsToExtract, r_minScale, r_maxScale, r_stepsPerOctave) {
@@ -490,8 +490,8 @@ reflectionMatrix <- function(r_image, r_axis, r_filename) {
     .Call(`_ANTsRCore_reflectionMatrix`, r_image, r_axis, r_filename)
 }
 
-reorientImage <- function(r_in_image1, r_txfn, r_axis1, r_axis2, rrfl, rscl) {
-    .Call(`_ANTsRCore_reorientImage`, r_in_image1, r_txfn, r_axis1, r_axis2, rrfl, rscl)
+reorientImageR <- function(r_in_image1, r_txfn, r_axis1, r_axis2, rrfl, rscl) {
+    .Call(`_ANTsRCore_reorientImageR`, r_in_image1, r_txfn, r_axis1, r_axis2, rrfl, rscl)
 }
 
 centerOfMass <- function(r_in_image1) {
@@ -514,19 +514,19 @@ sccanCpp <- function(r_X, r_Y, r_maskx, r_masky, r_sparsenessx, r_sparsenessy, r
     .Call(`_ANTsRCore_sccanCpp`, r_X, r_Y, r_maskx, r_masky, r_sparsenessx, r_sparsenessy, r_nvecs, r_its, r_cthreshx, r_cthreshy, r_z, r_smooth, r_initializationListx, r_initializationListy, r_mycoption, r_ell1, r_verbose, r_priorWeight, r_maxBasedThresh)
 }
 
-smoothImage <- function(r_inimg, r_outimg, r_sigma, sigmaInPhysicalCoordinates, r_kernelwidth) {
-    .Call(`_ANTsRCore_smoothImage`, r_inimg, r_outimg, r_sigma, sigmaInPhysicalCoordinates, r_kernelwidth)
+smoothImageR <- function(r_inimg, r_outimg, r_sigma, sigmaInPhysicalCoordinates, r_kernelwidth) {
+    .Call(`_ANTsRCore_smoothImageR`, r_inimg, r_outimg, r_sigma, sigmaInPhysicalCoordinates, r_kernelwidth)
 }
 
-splitChannels <- function(r_antsimage) {
-    .Call(`_ANTsRCore_splitChannels`, r_antsimage)
+splitChannelsR <- function(r_antsimage) {
+    .Call(`_ANTsRCore_splitChannelsR`, r_antsimage)
 }
 
 timeSeriesSubtraction <- function(r_antsimage, method) {
     .Call(`_ANTsRCore_timeSeriesSubtraction`, r_antsimage, method)
 }
 
-weingartenImageCurvature <- function(r_antsimage, r_sigma, r_opt, r_labeled) {
-    .Call(`_ANTsRCore_weingartenImageCurvature`, r_antsimage, r_sigma, r_opt, r_labeled)
+weingartenImageCurvatureR <- function(r_antsimage, r_sigma, r_opt, r_labeled) {
+    .Call(`_ANTsRCore_weingartenImageCurvatureR`, r_antsimage, r_sigma, r_opt, r_labeled)
 }
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -30,16 +30,16 @@ DenoiseImage <- function(r_args) {
     .Call(`_ANTsRCore_DenoiseImage`, r_args)
 }
 
-fitBsplineDisplacementField <- function(r_dimensionality, r_displacementField, r_displacementFieldWeightImage, r_displacementOrigins, r_displacements, r_displacementWeights, r_origin, r_spacing, r_size, r_direction, r_numberOfFittingLevels, r_numberOfControlPoints, r_splineOrder, r_enforceStationaryBoundary, r_estimateInverse, r_rasterizePoints) {
-    .Call(`_ANTsRCore_fitBsplineDisplacementField`, r_dimensionality, r_displacementField, r_displacementFieldWeightImage, r_displacementOrigins, r_displacements, r_displacementWeights, r_origin, r_spacing, r_size, r_direction, r_numberOfFittingLevels, r_numberOfControlPoints, r_splineOrder, r_enforceStationaryBoundary, r_estimateInverse, r_rasterizePoints)
+fitBsplineDisplacementFieldR <- function(r_dimensionality, r_displacementField, r_displacementFieldWeightImage, r_displacementOrigins, r_displacements, r_displacementWeights, r_origin, r_spacing, r_size, r_direction, r_numberOfFittingLevels, r_numberOfControlPoints, r_splineOrder, r_enforceStationaryBoundary, r_estimateInverse, r_rasterizePoints) {
+    .Call(`_ANTsRCore_fitBsplineDisplacementFieldR`, r_dimensionality, r_displacementField, r_displacementFieldWeightImage, r_displacementOrigins, r_displacements, r_displacementWeights, r_origin, r_spacing, r_size, r_direction, r_numberOfFittingLevels, r_numberOfControlPoints, r_splineOrder, r_enforceStationaryBoundary, r_estimateInverse, r_rasterizePoints)
 }
 
-fitBsplineObjectToScatteredData <- function(r_scatteredData, r_parametricData, r_dataWeights, r_parametricDomainOrigin, r_parametricDomainSpacing, r_parametricDomainSize, r_isParametricDimensionClosed, r_numberOfFittingLevels, r_numberOfControlPoints, r_splineOrder) {
-    .Call(`_ANTsRCore_fitBsplineObjectToScatteredData`, r_scatteredData, r_parametricData, r_dataWeights, r_parametricDomainOrigin, r_parametricDomainSpacing, r_parametricDomainSize, r_isParametricDimensionClosed, r_numberOfFittingLevels, r_numberOfControlPoints, r_splineOrder)
+fitBsplineObjectToScatteredDataR <- function(r_scatteredData, r_parametricData, r_dataWeights, r_parametricDomainOrigin, r_parametricDomainSpacing, r_parametricDomainSize, r_isParametricDimensionClosed, r_numberOfFittingLevels, r_numberOfControlPoints, r_splineOrder) {
+    .Call(`_ANTsRCore_fitBsplineObjectToScatteredDataR`, r_scatteredData, r_parametricData, r_dataWeights, r_parametricDomainOrigin, r_parametricDomainSpacing, r_parametricDomainSize, r_isParametricDimensionClosed, r_numberOfFittingLevels, r_numberOfControlPoints, r_splineOrder)
 }
 
-fitThinPlateSplineDisplacementField <- function(r_dimensionality, r_displacementOrigins, r_displacements, r_origin, r_spacing, r_size, r_direction) {
-    .Call(`_ANTsRCore_fitThinPlateSplineDisplacementField`, r_dimensionality, r_displacementOrigins, r_displacements, r_origin, r_spacing, r_size, r_direction)
+fitThinPlateSplineDisplacementFieldR <- function(r_dimensionality, r_displacementOrigins, r_displacements, r_origin, r_spacing, r_size, r_direction) {
+    .Call(`_ANTsRCore_fitThinPlateSplineDisplacementFieldR`, r_dimensionality, r_displacementOrigins, r_displacements, r_origin, r_spacing, r_size, r_direction)
 }
 
 HausdorffDistanceR <- function(r_inputImage1, r_inputImage2) {
@@ -50,12 +50,12 @@ histogramMatchImageR <- function(r_sourceImage, r_referenceImage, r_numberOfHist
     .Call(`_ANTsRCore_histogramMatchImageR`, r_sourceImage, r_referenceImage, r_numberOfHistogramBins, r_numberOfMatchPoints, r_useThresholdAtMeanIntensity)
 }
 
-integrateVelocityField <- function(r_dimensionality, r_velocityField, r_lowerBound, r_upperBound, r_numberOfIntegrationSteps) {
-    .Call(`_ANTsRCore_integrateVelocityField`, r_dimensionality, r_velocityField, r_lowerBound, r_upperBound, r_numberOfIntegrationSteps)
+integrateVelocityFieldR <- function(r_dimensionality, r_velocityField, r_lowerBound, r_upperBound, r_numberOfIntegrationSteps) {
+    .Call(`_ANTsRCore_integrateVelocityFieldR`, r_dimensionality, r_velocityField, r_lowerBound, r_upperBound, r_numberOfIntegrationSteps)
 }
 
-invertDisplacementField <- function(r_dimensionality, r_displacementField, r_inverseFieldInitialEstimate, r_maxNumberOfIterations, r_meanErrorToleranceThreshold, r_maxErrorToleranceThreshold, r_enforceBoundaryCondition) {
-    .Call(`_ANTsRCore_invertDisplacementField`, r_dimensionality, r_displacementField, r_inverseFieldInitialEstimate, r_maxNumberOfIterations, r_meanErrorToleranceThreshold, r_maxErrorToleranceThreshold, r_enforceBoundaryCondition)
+invertDisplacementFieldR <- function(r_dimensionality, r_displacementField, r_inverseFieldInitialEstimate, r_maxNumberOfIterations, r_meanErrorToleranceThreshold, r_maxErrorToleranceThreshold, r_enforceBoundaryCondition) {
+    .Call(`_ANTsRCore_invertDisplacementFieldR`, r_dimensionality, r_displacementField, r_inverseFieldInitialEstimate, r_maxNumberOfIterations, r_meanErrorToleranceThreshold, r_maxErrorToleranceThreshold, r_enforceBoundaryCondition)
 }
 
 KellyKapowski <- function(r_args) {
@@ -446,8 +446,8 @@ iMathInterface2 <- function(r_args) {
     .Call(`_ANTsRCore_iMathInterface2`, r_args)
 }
 
-imagesToMatrix <- function(r_fns, r_mask, r_n) {
-    .Call(`_ANTsRCore_imagesToMatrix`, r_fns, r_mask, r_n)
+imagesToMatrixR <- function(r_fns, r_mask, r_n) {
+    .Call(`_ANTsRCore_imagesToMatrixR`, r_fns, r_mask, r_n)
 }
 
 invariantImageSimilarity <- function(r_in_image1, r_in_image2, thetas, thetas2, thetas3, localSearchIterations, whichMetric, r_scale, r_doref, txfn, whichTransform, r_mask) {
@@ -486,8 +486,8 @@ rcpp_hello_world33 <- function() {
     .Call(`_ANTsRCore_rcpp_hello_world33`)
 }
 
-reflectionMatrix <- function(r_image, r_axis, r_filename) {
-    .Call(`_ANTsRCore_reflectionMatrix`, r_image, r_axis, r_filename)
+reflectionMatrixR <- function(r_image, r_axis, r_filename) {
+    .Call(`_ANTsRCore_reflectionMatrixR`, r_image, r_axis, r_filename)
 }
 
 reorientImageR <- function(r_in_image1, r_txfn, r_axis1, r_axis2, rrfl, rscl) {

--- a/src/FitBSplineDisplacementField.cpp
+++ b/src/FitBSplineDisplacementField.cpp
@@ -305,7 +305,7 @@ SEXP fitBSplineVectorImageHelper(
 }
 
 // [[Rcpp::export]]
-SEXP fitBsplineDisplacementField(
+SEXP fitBsplineDisplacementFieldR(
   SEXP r_dimensionality,
   SEXP r_displacementField,
   SEXP r_displacementFieldWeightImage,

--- a/src/FitBSplineObjectToScatteredData.cpp
+++ b/src/FitBSplineObjectToScatteredData.cpp
@@ -349,7 +349,7 @@ SEXP fitBSplineVectorImageHelper(
 }
 
 // [[Rcpp::export]]
-SEXP fitBsplineObjectToScatteredData(
+SEXP fitBsplineObjectToScatteredDataR(
   SEXP r_scatteredData,
   SEXP r_parametricData,
   SEXP r_dataWeights,

--- a/src/FitThinPlateSplineDisplacementField.cpp
+++ b/src/FitThinPlateSplineDisplacementField.cpp
@@ -132,7 +132,7 @@ SEXP fitThinPlateSplineVectorImageHelper(
 }
 
 // [[Rcpp::export]]
-SEXP fitThinPlateSplineDisplacementField(
+SEXP fitThinPlateSplineDisplacementFieldR(
   SEXP r_dimensionality,
   SEXP r_displacementOrigins,
   SEXP r_displacements,

--- a/src/IntegrateVelocityField.cpp
+++ b/src/IntegrateVelocityField.cpp
@@ -93,7 +93,7 @@ SEXP integrateVelocityFieldHelper(
 }
 
 // [[Rcpp::export]]
-SEXP integrateVelocityField(
+SEXP integrateVelocityFieldR(
   SEXP r_dimensionality,
   SEXP r_velocityField,
   SEXP r_lowerBound,

--- a/src/InvertDisplacementField.cpp
+++ b/src/InvertDisplacementField.cpp
@@ -103,7 +103,7 @@ SEXP invertDisplacementFieldHelper(
 }
 
 // [[Rcpp::export]]
-SEXP invertDisplacementField(
+SEXP invertDisplacementFieldR(
   SEXP r_dimensionality,  
   SEXP r_displacementField,
   SEXP r_inverseFieldInitialEstimate,

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -306,36 +306,36 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// antsAffineInitializer
-SEXP antsAffineInitializer(SEXP r_args);
-RcppExport SEXP _ANTsRCore_antsAffineInitializer(SEXP r_argsSEXP) {
+// AntsAffineInitializer
+SEXP AntsAffineInitializer(SEXP r_args);
+RcppExport SEXP _ANTsRCore_AntsAffineInitializer(SEXP r_argsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< SEXP >::type r_args(r_argsSEXP);
-    rcpp_result_gen = Rcpp::wrap(antsAffineInitializer(r_args));
+    rcpp_result_gen = Rcpp::wrap(AntsAffineInitializer(r_args));
     return rcpp_result_gen;
 END_RCPP
 }
-// antsApplyTransforms
-SEXP antsApplyTransforms(SEXP r_args);
-RcppExport SEXP _ANTsRCore_antsApplyTransforms(SEXP r_argsSEXP) {
+// AntsApplyTransforms
+SEXP AntsApplyTransforms(SEXP r_args);
+RcppExport SEXP _ANTsRCore_AntsApplyTransforms(SEXP r_argsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< SEXP >::type r_args(r_argsSEXP);
-    rcpp_result_gen = Rcpp::wrap(antsApplyTransforms(r_args));
+    rcpp_result_gen = Rcpp::wrap(AntsApplyTransforms(r_args));
     return rcpp_result_gen;
 END_RCPP
 }
-// antsApplyTransformsToPoints
-SEXP antsApplyTransformsToPoints(SEXP r_args);
-RcppExport SEXP _ANTsRCore_antsApplyTransformsToPoints(SEXP r_argsSEXP) {
+// AntsApplyTransformsToPoints
+SEXP AntsApplyTransformsToPoints(SEXP r_args);
+RcppExport SEXP _ANTsRCore_AntsApplyTransformsToPoints(SEXP r_argsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< SEXP >::type r_args(r_argsSEXP);
-    rcpp_result_gen = Rcpp::wrap(antsApplyTransformsToPoints(r_args));
+    rcpp_result_gen = Rcpp::wrap(AntsApplyTransformsToPoints(r_args));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -646,15 +646,15 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// antsImageClone
-SEXP antsImageClone(SEXP r_in_image, SEXP r_out_pixeltype);
-RcppExport SEXP _ANTsRCore_antsImageClone(SEXP r_in_imageSEXP, SEXP r_out_pixeltypeSEXP) {
+// AntsImageClone
+SEXP AntsImageClone(SEXP r_in_image, SEXP r_out_pixeltype);
+RcppExport SEXP _ANTsRCore_AntsImageClone(SEXP r_in_imageSEXP, SEXP r_out_pixeltypeSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< SEXP >::type r_in_image(r_in_imageSEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_out_pixeltype(r_out_pixeltypeSEXP);
-    rcpp_result_gen = Rcpp::wrap(antsImageClone(r_in_image, r_out_pixeltype));
+    rcpp_result_gen = Rcpp::wrap(AntsImageClone(r_in_image, r_out_pixeltype));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -684,25 +684,25 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// antsImageHeaderInfo
-SEXP antsImageHeaderInfo(SEXP r_filename);
-RcppExport SEXP _ANTsRCore_antsImageHeaderInfo(SEXP r_filenameSEXP) {
+// AntsImageHeaderInfo
+SEXP AntsImageHeaderInfo(SEXP r_filename);
+RcppExport SEXP _ANTsRCore_AntsImageHeaderInfo(SEXP r_filenameSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< SEXP >::type r_filename(r_filenameSEXP);
-    rcpp_result_gen = Rcpp::wrap(antsImageHeaderInfo(r_filename));
+    rcpp_result_gen = Rcpp::wrap(AntsImageHeaderInfo(r_filename));
     return rcpp_result_gen;
 END_RCPP
 }
-// antsImageIterator
-SEXP antsImageIterator(SEXP r_antsimage);
-RcppExport SEXP _ANTsRCore_antsImageIterator(SEXP r_antsimageSEXP) {
+// AntsImageIterator
+SEXP AntsImageIterator(SEXP r_antsimage);
+RcppExport SEXP _ANTsRCore_AntsImageIterator(SEXP r_antsimageSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< SEXP >::type r_antsimage(r_antsimageSEXP);
-    rcpp_result_gen = Rcpp::wrap(antsImageIterator(r_antsimage));
+    rcpp_result_gen = Rcpp::wrap(AntsImageIterator(r_antsimage));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -879,9 +879,9 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// antsImageRead
-SEXP antsImageRead(SEXP r_filename, SEXP r_pixeltype, SEXP r_dimension, SEXP r_components);
-RcppExport SEXP _ANTsRCore_antsImageRead(SEXP r_filenameSEXP, SEXP r_pixeltypeSEXP, SEXP r_dimensionSEXP, SEXP r_componentsSEXP) {
+// AntsImageRead
+SEXP AntsImageRead(SEXP r_filename, SEXP r_pixeltype, SEXP r_dimension, SEXP r_components);
+RcppExport SEXP _ANTsRCore_AntsImageRead(SEXP r_filenameSEXP, SEXP r_pixeltypeSEXP, SEXP r_dimensionSEXP, SEXP r_componentsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -889,33 +889,33 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< SEXP >::type r_pixeltype(r_pixeltypeSEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_dimension(r_dimensionSEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_components(r_componentsSEXP);
-    rcpp_result_gen = Rcpp::wrap(antsImageRead(r_filename, r_pixeltype, r_dimension, r_components));
+    rcpp_result_gen = Rcpp::wrap(AntsImageRead(r_filename, r_pixeltype, r_dimension, r_components));
     return rcpp_result_gen;
 END_RCPP
 }
-// antsImageStats
-SEXP antsImageStats(SEXP r_antsimage, SEXP r_mask, SEXP r_narm);
-RcppExport SEXP _ANTsRCore_antsImageStats(SEXP r_antsimageSEXP, SEXP r_maskSEXP, SEXP r_narmSEXP) {
+// AntsImageStats
+SEXP AntsImageStats(SEXP r_antsimage, SEXP r_mask, SEXP r_narm);
+RcppExport SEXP _ANTsRCore_AntsImageStats(SEXP r_antsimageSEXP, SEXP r_maskSEXP, SEXP r_narmSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< SEXP >::type r_antsimage(r_antsimageSEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_mask(r_maskSEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_narm(r_narmSEXP);
-    rcpp_result_gen = Rcpp::wrap(antsImageStats(r_antsimage, r_mask, r_narm));
+    rcpp_result_gen = Rcpp::wrap(AntsImageStats(r_antsimage, r_mask, r_narm));
     return rcpp_result_gen;
 END_RCPP
 }
-// antsImageWrite
-SEXP antsImageWrite(SEXP r_img, SEXP r_filename, SEXP r_asTensor);
-RcppExport SEXP _ANTsRCore_antsImageWrite(SEXP r_imgSEXP, SEXP r_filenameSEXP, SEXP r_asTensorSEXP) {
+// AntsImageWrite
+SEXP AntsImageWrite(SEXP r_img, SEXP r_filename, SEXP r_asTensor);
+RcppExport SEXP _ANTsRCore_AntsImageWrite(SEXP r_imgSEXP, SEXP r_filenameSEXP, SEXP r_asTensorSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< SEXP >::type r_img(r_imgSEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_filename(r_filenameSEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_asTensor(r_asTensorSEXP);
-    rcpp_result_gen = Rcpp::wrap(antsImageWrite(r_img, r_filename, r_asTensor));
+    rcpp_result_gen = Rcpp::wrap(AntsImageWrite(r_img, r_filename, r_asTensor));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -964,14 +964,14 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// antsMotionCorr
-SEXP antsMotionCorr(SEXP r_args);
-RcppExport SEXP _ANTsRCore_antsMotionCorr(SEXP r_argsSEXP) {
+// AntsMotionCorr
+SEXP AntsMotionCorr(SEXP r_args);
+RcppExport SEXP _ANTsRCore_AntsMotionCorr(SEXP r_argsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< SEXP >::type r_args(r_argsSEXP);
-    rcpp_result_gen = Rcpp::wrap(antsMotionCorr(r_args));
+    rcpp_result_gen = Rcpp::wrap(AntsMotionCorr(r_args));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -989,14 +989,14 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// antsRegistration
-SEXP antsRegistration(SEXP r_args);
-RcppExport SEXP _ANTsRCore_antsRegistration(SEXP r_argsSEXP) {
+// AntsRegistration
+SEXP AntsRegistration(SEXP r_args);
+RcppExport SEXP _ANTsRCore_AntsRegistration(SEXP r_argsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< SEXP >::type r_args(r_argsSEXP);
-    rcpp_result_gen = Rcpp::wrap(antsRegistration(r_args));
+    rcpp_result_gen = Rcpp::wrap(AntsRegistration(r_args));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1301,9 +1301,9 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// cropImage
-SEXP cropImage(SEXP r_in_image1, SEXP r_in_image2, SEXP r_label, SEXP r_decrop, SEXP r_loind, SEXP r_upind);
-RcppExport SEXP _ANTsRCore_cropImage(SEXP r_in_image1SEXP, SEXP r_in_image2SEXP, SEXP r_labelSEXP, SEXP r_decropSEXP, SEXP r_loindSEXP, SEXP r_upindSEXP) {
+// CropImage
+SEXP CropImage(SEXP r_in_image1, SEXP r_in_image2, SEXP r_label, SEXP r_decrop, SEXP r_loind, SEXP r_upind);
+RcppExport SEXP _ANTsRCore_CropImage(SEXP r_in_image1SEXP, SEXP r_in_image2SEXP, SEXP r_labelSEXP, SEXP r_decropSEXP, SEXP r_loindSEXP, SEXP r_upindSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -1313,13 +1313,13 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< SEXP >::type r_decrop(r_decropSEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_loind(r_loindSEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_upind(r_upindSEXP);
-    rcpp_result_gen = Rcpp::wrap(cropImage(r_in_image1, r_in_image2, r_label, r_decrop, r_loind, r_upind));
+    rcpp_result_gen = Rcpp::wrap(CropImage(r_in_image1, r_in_image2, r_label, r_decrop, r_loind, r_upind));
     return rcpp_result_gen;
 END_RCPP
 }
-// extractSlice
-SEXP extractSlice(SEXP r_in_image1, SEXP r_slice, SEXP r_direction, SEXP r_collapseStrategy);
-RcppExport SEXP _ANTsRCore_extractSlice(SEXP r_in_image1SEXP, SEXP r_sliceSEXP, SEXP r_directionSEXP, SEXP r_collapseStrategySEXP) {
+// ExtractSlice
+SEXP ExtractSlice(SEXP r_in_image1, SEXP r_slice, SEXP r_direction, SEXP r_collapseStrategy);
+RcppExport SEXP _ANTsRCore_ExtractSlice(SEXP r_in_image1SEXP, SEXP r_sliceSEXP, SEXP r_directionSEXP, SEXP r_collapseStrategySEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -1327,7 +1327,7 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< SEXP >::type r_slice(r_sliceSEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_direction(r_directionSEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_collapseStrategy(r_collapseStrategySEXP);
-    rcpp_result_gen = Rcpp::wrap(extractSlice(r_in_image1, r_slice, r_direction, r_collapseStrategy));
+    rcpp_result_gen = Rcpp::wrap(ExtractSlice(r_in_image1, r_slice, r_direction, r_collapseStrategy));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1344,9 +1344,9 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// fsl2antsrTransform
-SEXP fsl2antsrTransform(SEXP r_matrix, SEXP r_reference, SEXP r_moving, SEXP r_flag);
-RcppExport SEXP _ANTsRCore_fsl2antsrTransform(SEXP r_matrixSEXP, SEXP r_referenceSEXP, SEXP r_movingSEXP, SEXP r_flagSEXP) {
+// fsl2antsrTransformR
+SEXP fsl2antsrTransformR(SEXP r_matrix, SEXP r_reference, SEXP r_moving, SEXP r_flag);
+RcppExport SEXP _ANTsRCore_fsl2antsrTransformR(SEXP r_matrixSEXP, SEXP r_referenceSEXP, SEXP r_movingSEXP, SEXP r_flagSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -1354,7 +1354,7 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< SEXP >::type r_reference(r_referenceSEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_moving(r_movingSEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_flag(r_flagSEXP);
-    rcpp_result_gen = Rcpp::wrap(fsl2antsrTransform(r_matrix, r_reference, r_moving, r_flag));
+    rcpp_result_gen = Rcpp::wrap(fsl2antsrTransformR(r_matrix, r_reference, r_moving, r_flag));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1438,21 +1438,21 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// labelStats
-SEXP labelStats(SEXP r_image, SEXP r_labelImage);
-RcppExport SEXP _ANTsRCore_labelStats(SEXP r_imageSEXP, SEXP r_labelImageSEXP) {
+// labelStatsR
+SEXP labelStatsR(SEXP r_image, SEXP r_labelImage);
+RcppExport SEXP _ANTsRCore_labelStatsR(SEXP r_imageSEXP, SEXP r_labelImageSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< SEXP >::type r_image(r_imageSEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_labelImage(r_labelImageSEXP);
-    rcpp_result_gen = Rcpp::wrap(labelStats(r_image, r_labelImage));
+    rcpp_result_gen = Rcpp::wrap(labelStatsR(r_image, r_labelImage));
     return rcpp_result_gen;
 END_RCPP
 }
-// makeImage
-SEXP makeImage(SEXP r_pixeltype, SEXP r_size, SEXP r_spacing, SEXP r_origin, SEXP r_direction, SEXP r_components);
-RcppExport SEXP _ANTsRCore_makeImage(SEXP r_pixeltypeSEXP, SEXP r_sizeSEXP, SEXP r_spacingSEXP, SEXP r_originSEXP, SEXP r_directionSEXP, SEXP r_componentsSEXP) {
+// makeImageR
+SEXP makeImageR(SEXP r_pixeltype, SEXP r_size, SEXP r_spacing, SEXP r_origin, SEXP r_direction, SEXP r_components);
+RcppExport SEXP _ANTsRCore_makeImageR(SEXP r_pixeltypeSEXP, SEXP r_sizeSEXP, SEXP r_spacingSEXP, SEXP r_originSEXP, SEXP r_directionSEXP, SEXP r_componentsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -1462,18 +1462,18 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< SEXP >::type r_origin(r_originSEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_direction(r_directionSEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_components(r_componentsSEXP);
-    rcpp_result_gen = Rcpp::wrap(makeImage(r_pixeltype, r_size, r_spacing, r_origin, r_direction, r_components));
+    rcpp_result_gen = Rcpp::wrap(makeImageR(r_pixeltype, r_size, r_spacing, r_origin, r_direction, r_components));
     return rcpp_result_gen;
 END_RCPP
 }
-// mergeChannels
-SEXP mergeChannels(SEXP r_imageList);
-RcppExport SEXP _ANTsRCore_mergeChannels(SEXP r_imageListSEXP) {
+// mergeChannelsR
+SEXP mergeChannelsR(SEXP r_imageList);
+RcppExport SEXP _ANTsRCore_mergeChannelsR(SEXP r_imageListSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< SEXP >::type r_imageList(r_imageListSEXP);
-    rcpp_result_gen = Rcpp::wrap(mergeChannels(r_imageList));
+    rcpp_result_gen = Rcpp::wrap(mergeChannelsR(r_imageList));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1548,9 +1548,9 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// reorientImage
-SEXP reorientImage(SEXP r_in_image1, SEXP r_txfn, SEXP r_axis1, SEXP r_axis2, SEXP rrfl, SEXP rscl);
-RcppExport SEXP _ANTsRCore_reorientImage(SEXP r_in_image1SEXP, SEXP r_txfnSEXP, SEXP r_axis1SEXP, SEXP r_axis2SEXP, SEXP rrflSEXP, SEXP rsclSEXP) {
+// reorientImageR
+SEXP reorientImageR(SEXP r_in_image1, SEXP r_txfn, SEXP r_axis1, SEXP r_axis2, SEXP rrfl, SEXP rscl);
+RcppExport SEXP _ANTsRCore_reorientImageR(SEXP r_in_image1SEXP, SEXP r_txfnSEXP, SEXP r_axis1SEXP, SEXP r_axis2SEXP, SEXP rrflSEXP, SEXP rsclSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -1560,7 +1560,7 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< SEXP >::type r_axis2(r_axis2SEXP);
     Rcpp::traits::input_parameter< SEXP >::type rrfl(rrflSEXP);
     Rcpp::traits::input_parameter< SEXP >::type rscl(rsclSEXP);
-    rcpp_result_gen = Rcpp::wrap(reorientImage(r_in_image1, r_txfn, r_axis1, r_axis2, rrfl, rscl));
+    rcpp_result_gen = Rcpp::wrap(reorientImageR(r_in_image1, r_txfn, r_axis1, r_axis2, rrfl, rscl));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1651,9 +1651,9 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// smoothImage
-SEXP smoothImage(SEXP r_inimg, SEXP r_outimg, SEXP r_sigma, SEXP sigmaInPhysicalCoordinates, SEXP r_kernelwidth);
-RcppExport SEXP _ANTsRCore_smoothImage(SEXP r_inimgSEXP, SEXP r_outimgSEXP, SEXP r_sigmaSEXP, SEXP sigmaInPhysicalCoordinatesSEXP, SEXP r_kernelwidthSEXP) {
+// smoothImageR
+SEXP smoothImageR(SEXP r_inimg, SEXP r_outimg, SEXP r_sigma, SEXP sigmaInPhysicalCoordinates, SEXP r_kernelwidth);
+RcppExport SEXP _ANTsRCore_smoothImageR(SEXP r_inimgSEXP, SEXP r_outimgSEXP, SEXP r_sigmaSEXP, SEXP sigmaInPhysicalCoordinatesSEXP, SEXP r_kernelwidthSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -1662,18 +1662,18 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< SEXP >::type r_sigma(r_sigmaSEXP);
     Rcpp::traits::input_parameter< SEXP >::type sigmaInPhysicalCoordinates(sigmaInPhysicalCoordinatesSEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_kernelwidth(r_kernelwidthSEXP);
-    rcpp_result_gen = Rcpp::wrap(smoothImage(r_inimg, r_outimg, r_sigma, sigmaInPhysicalCoordinates, r_kernelwidth));
+    rcpp_result_gen = Rcpp::wrap(smoothImageR(r_inimg, r_outimg, r_sigma, sigmaInPhysicalCoordinates, r_kernelwidth));
     return rcpp_result_gen;
 END_RCPP
 }
-// splitChannels
-SEXP splitChannels(SEXP r_antsimage);
-RcppExport SEXP _ANTsRCore_splitChannels(SEXP r_antsimageSEXP) {
+// splitChannelsR
+SEXP splitChannelsR(SEXP r_antsimage);
+RcppExport SEXP _ANTsRCore_splitChannelsR(SEXP r_antsimageSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< SEXP >::type r_antsimage(r_antsimageSEXP);
-    rcpp_result_gen = Rcpp::wrap(splitChannels(r_antsimage));
+    rcpp_result_gen = Rcpp::wrap(splitChannelsR(r_antsimage));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1689,9 +1689,9 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// weingartenImageCurvature
-SEXP weingartenImageCurvature(SEXP r_antsimage, SEXP r_sigma, SEXP r_opt, SEXP r_labeled);
-RcppExport SEXP _ANTsRCore_weingartenImageCurvature(SEXP r_antsimageSEXP, SEXP r_sigmaSEXP, SEXP r_optSEXP, SEXP r_labeledSEXP) {
+// weingartenImageCurvatureR
+SEXP weingartenImageCurvatureR(SEXP r_antsimage, SEXP r_sigma, SEXP r_opt, SEXP r_labeled);
+RcppExport SEXP _ANTsRCore_weingartenImageCurvatureR(SEXP r_antsimageSEXP, SEXP r_sigmaSEXP, SEXP r_optSEXP, SEXP r_labeledSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -1699,7 +1699,7 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< SEXP >::type r_sigma(r_sigmaSEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_opt(r_optSEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_labeled(r_labeledSEXP);
-    rcpp_result_gen = Rcpp::wrap(weingartenImageCurvature(r_antsimage, r_sigma, r_opt, r_labeled));
+    rcpp_result_gen = Rcpp::wrap(weingartenImageCurvatureR(r_antsimage, r_sigma, r_opt, r_labeled));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1726,9 +1726,9 @@ static const R_CallMethodDef CallEntries[] = {
     {"_ANTsRCore_simulateBSplineDisplacementFieldR", (DL_FUNC) &_ANTsRCore_simulateBSplineDisplacementFieldR, 6},
     {"_ANTsRCore_simulateExponentialDisplacementFieldR", (DL_FUNC) &_ANTsRCore_simulateExponentialDisplacementFieldR, 5},
     {"_ANTsRCore_ThresholdImage", (DL_FUNC) &_ANTsRCore_ThresholdImage, 1},
-    {"_ANTsRCore_antsAffineInitializer", (DL_FUNC) &_ANTsRCore_antsAffineInitializer, 1},
-    {"_ANTsRCore_antsApplyTransforms", (DL_FUNC) &_ANTsRCore_antsApplyTransforms, 1},
-    {"_ANTsRCore_antsApplyTransformsToPoints", (DL_FUNC) &_ANTsRCore_antsApplyTransformsToPoints, 1},
+    {"_ANTsRCore_AntsAffineInitializer", (DL_FUNC) &_ANTsRCore_AntsAffineInitializer, 1},
+    {"_ANTsRCore_AntsApplyTransforms", (DL_FUNC) &_ANTsRCore_AntsApplyTransforms, 1},
+    {"_ANTsRCore_AntsApplyTransformsToPoints", (DL_FUNC) &_ANTsRCore_AntsApplyTransformsToPoints, 1},
     {"_ANTsRCore_antsImage", (DL_FUNC) &_ANTsRCore_antsImage, 3},
     {"_ANTsRCore_antsImageArith", (DL_FUNC) &_ANTsRCore_antsImageArith, 3},
     {"_ANTsRCore_antsImage_isna", (DL_FUNC) &_ANTsRCore_antsImage_isna, 1},
@@ -1753,11 +1753,11 @@ static const R_CallMethodDef CallEntries[] = {
     {"_ANTsRCore_antsImageArithImageNumeric", (DL_FUNC) &_ANTsRCore_antsImageArithImageNumeric, 3},
     {"_ANTsRCore_antsImageArithNumericImage", (DL_FUNC) &_ANTsRCore_antsImageArithNumericImage, 3},
     {"_ANTsRCore_antsImageArithImageImage", (DL_FUNC) &_ANTsRCore_antsImageArithImageImage, 3},
-    {"_ANTsRCore_antsImageClone", (DL_FUNC) &_ANTsRCore_antsImageClone, 2},
+    {"_ANTsRCore_AntsImageClone", (DL_FUNC) &_ANTsRCore_AntsImageClone, 2},
     {"_ANTsRCore_antsImageComparisonImageNumeric", (DL_FUNC) &_ANTsRCore_antsImageComparisonImageNumeric, 3},
     {"_ANTsRCore_antsImageComparisonImageImage", (DL_FUNC) &_ANTsRCore_antsImageComparisonImageImage, 3},
-    {"_ANTsRCore_antsImageHeaderInfo", (DL_FUNC) &_ANTsRCore_antsImageHeaderInfo, 1},
-    {"_ANTsRCore_antsImageIterator", (DL_FUNC) &_ANTsRCore_antsImageIterator, 1},
+    {"_ANTsRCore_AntsImageHeaderInfo", (DL_FUNC) &_ANTsRCore_AntsImageHeaderInfo, 1},
+    {"_ANTsRCore_AntsImageIterator", (DL_FUNC) &_ANTsRCore_AntsImageIterator, 1},
     {"_ANTsRCore_antsImageIterator_Get", (DL_FUNC) &_ANTsRCore_antsImageIterator_Get, 1},
     {"_ANTsRCore_antsImageIterator_Set", (DL_FUNC) &_ANTsRCore_antsImageIterator_Set, 2},
     {"_ANTsRCore_antsImageIterator_Next", (DL_FUNC) &_ANTsRCore_antsImageIterator_Next, 1},
@@ -1773,16 +1773,16 @@ static const R_CallMethodDef CallEntries[] = {
     {"_ANTsRCore_antsImageLogicImageImage", (DL_FUNC) &_ANTsRCore_antsImageLogicImageImage, 3},
     {"_ANTsRCore_antsImageMath", (DL_FUNC) &_ANTsRCore_antsImageMath, 2},
     {"_ANTsRCore_antsImageMutualInformation", (DL_FUNC) &_ANTsRCore_antsImageMutualInformation, 2},
-    {"_ANTsRCore_antsImageRead", (DL_FUNC) &_ANTsRCore_antsImageRead, 4},
-    {"_ANTsRCore_antsImageStats", (DL_FUNC) &_ANTsRCore_antsImageStats, 3},
-    {"_ANTsRCore_antsImageWrite", (DL_FUNC) &_ANTsRCore_antsImageWrite, 3},
+    {"_ANTsRCore_AntsImageRead", (DL_FUNC) &_ANTsRCore_AntsImageRead, 4},
+    {"_ANTsRCore_AntsImageStats", (DL_FUNC) &_ANTsRCore_AntsImageStats, 3},
+    {"_ANTsRCore_AntsImageWrite", (DL_FUNC) &_ANTsRCore_AntsImageWrite, 3},
     {"_ANTsRCore_antsJointFusion", (DL_FUNC) &_ANTsRCore_antsJointFusion, 1},
     {"_ANTsRCore_antsMatrix", (DL_FUNC) &_ANTsRCore_antsMatrix, 1},
     {"_ANTsRCore_antsMatrix_asList", (DL_FUNC) &_ANTsRCore_antsMatrix_asList, 1},
     {"_ANTsRCore_antsMatrix_asantsMatrix", (DL_FUNC) &_ANTsRCore_antsMatrix_asantsMatrix, 2},
-    {"_ANTsRCore_antsMotionCorr", (DL_FUNC) &_ANTsRCore_antsMotionCorr, 1},
+    {"_ANTsRCore_AntsMotionCorr", (DL_FUNC) &_ANTsRCore_AntsMotionCorr, 1},
     {"_ANTsRCore_antsMotionCorrStats", (DL_FUNC) &_ANTsRCore_antsMotionCorrStats, 4},
-    {"_ANTsRCore_antsRegistration", (DL_FUNC) &_ANTsRCore_antsRegistration, 1},
+    {"_ANTsRCore_AntsRegistration", (DL_FUNC) &_ANTsRCore_AntsRegistration, 1},
     {"_ANTsRCore_antsrMetric", (DL_FUNC) &_ANTsRCore_antsrMetric, 6},
     {"_ANTsRCore_antsrMetric_SetImage", (DL_FUNC) &_ANTsRCore_antsrMetric_SetImage, 4},
     {"_ANTsRCore_antsrMetric_SetTransform", (DL_FUNC) &_ANTsRCore_antsrMetric_SetTransform, 3},
@@ -1807,34 +1807,34 @@ static const R_CallMethodDef CallEntries[] = {
     {"_ANTsRCore_antsrTransform_ToDisplacementField", (DL_FUNC) &_ANTsRCore_antsrTransform_ToDisplacementField, 2},
     {"_ANTsRCore_antsrTransform_Inverse", (DL_FUNC) &_ANTsRCore_antsrTransform_Inverse, 1},
     {"_ANTsRCore_antsrTransform_Write", (DL_FUNC) &_ANTsRCore_antsrTransform_Write, 2},
-    {"_ANTsRCore_cropImage", (DL_FUNC) &_ANTsRCore_cropImage, 6},
-    {"_ANTsRCore_extractSlice", (DL_FUNC) &_ANTsRCore_extractSlice, 4},
+    {"_ANTsRCore_CropImage", (DL_FUNC) &_ANTsRCore_CropImage, 6},
+    {"_ANTsRCore_ExtractSlice", (DL_FUNC) &_ANTsRCore_ExtractSlice, 4},
     {"_ANTsRCore_fastMarchingExtension", (DL_FUNC) &_ANTsRCore_fastMarchingExtension, 3},
-    {"_ANTsRCore_fsl2antsrTransform", (DL_FUNC) &_ANTsRCore_fsl2antsrTransform, 4},
+    {"_ANTsRCore_fsl2antsrTransformR", (DL_FUNC) &_ANTsRCore_fsl2antsrTransformR, 4},
     {"_ANTsRCore_iMathInterface", (DL_FUNC) &_ANTsRCore_iMathInterface, 1},
     {"_ANTsRCore_iMathInterface1", (DL_FUNC) &_ANTsRCore_iMathInterface1, 1},
     {"_ANTsRCore_iMathInterface2", (DL_FUNC) &_ANTsRCore_iMathInterface2, 1},
     {"_ANTsRCore_imagesToMatrix", (DL_FUNC) &_ANTsRCore_imagesToMatrix, 3},
     {"_ANTsRCore_invariantImageSimilarity", (DL_FUNC) &_ANTsRCore_invariantImageSimilarity, 12},
     {"_ANTsRCore_itkConvolveImage", (DL_FUNC) &_ANTsRCore_itkConvolveImage, 2},
-    {"_ANTsRCore_labelStats", (DL_FUNC) &_ANTsRCore_labelStats, 2},
-    {"_ANTsRCore_makeImage", (DL_FUNC) &_ANTsRCore_makeImage, 6},
-    {"_ANTsRCore_mergeChannels", (DL_FUNC) &_ANTsRCore_mergeChannels, 1},
+    {"_ANTsRCore_labelStatsR", (DL_FUNC) &_ANTsRCore_labelStatsR, 2},
+    {"_ANTsRCore_makeImageR", (DL_FUNC) &_ANTsRCore_makeImageR, 6},
+    {"_ANTsRCore_mergeChannelsR", (DL_FUNC) &_ANTsRCore_mergeChannelsR, 1},
     {"_ANTsRCore_blobAnalysis", (DL_FUNC) &_ANTsRCore_blobAnalysis, 6},
     {"_ANTsRCore_patchAnalysis", (DL_FUNC) &_ANTsRCore_patchAnalysis, 12},
     {"_ANTsRCore_rcpp_hello_world22", (DL_FUNC) &_ANTsRCore_rcpp_hello_world22, 0},
     {"_ANTsRCore_rcpp_hello_world33", (DL_FUNC) &_ANTsRCore_rcpp_hello_world33, 0},
     {"_ANTsRCore_reflectionMatrix", (DL_FUNC) &_ANTsRCore_reflectionMatrix, 3},
-    {"_ANTsRCore_reorientImage", (DL_FUNC) &_ANTsRCore_reorientImage, 6},
+    {"_ANTsRCore_reorientImageR", (DL_FUNC) &_ANTsRCore_reorientImageR, 6},
     {"_ANTsRCore_centerOfMass", (DL_FUNC) &_ANTsRCore_centerOfMass, 1},
     {"_ANTsRCore_sccanX", (DL_FUNC) &_ANTsRCore_sccanX, 1},
     {"_ANTsRCore_robustMatrixTransform", (DL_FUNC) &_ANTsRCore_robustMatrixTransform, 1},
     {"_ANTsRCore_eigenanatomyCpp", (DL_FUNC) &_ANTsRCore_eigenanatomyCpp, 15},
     {"_ANTsRCore_sccanCpp", (DL_FUNC) &_ANTsRCore_sccanCpp, 19},
-    {"_ANTsRCore_smoothImage", (DL_FUNC) &_ANTsRCore_smoothImage, 5},
-    {"_ANTsRCore_splitChannels", (DL_FUNC) &_ANTsRCore_splitChannels, 1},
+    {"_ANTsRCore_smoothImageR", (DL_FUNC) &_ANTsRCore_smoothImageR, 5},
+    {"_ANTsRCore_splitChannelsR", (DL_FUNC) &_ANTsRCore_splitChannelsR, 1},
     {"_ANTsRCore_timeSeriesSubtraction", (DL_FUNC) &_ANTsRCore_timeSeriesSubtraction, 2},
-    {"_ANTsRCore_weingartenImageCurvature", (DL_FUNC) &_ANTsRCore_weingartenImageCurvature, 4},
+    {"_ANTsRCore_weingartenImageCurvatureR", (DL_FUNC) &_ANTsRCore_weingartenImageCurvatureR, 4},
     {NULL, NULL, 0}
 };
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -75,9 +75,9 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// fitBsplineDisplacementField
-SEXP fitBsplineDisplacementField(SEXP r_dimensionality, SEXP r_displacementField, SEXP r_displacementFieldWeightImage, SEXP r_displacementOrigins, SEXP r_displacements, SEXP r_displacementWeights, SEXP r_origin, SEXP r_spacing, SEXP r_size, SEXP r_direction, SEXP r_numberOfFittingLevels, SEXP r_numberOfControlPoints, SEXP r_splineOrder, SEXP r_enforceStationaryBoundary, SEXP r_estimateInverse, SEXP r_rasterizePoints);
-RcppExport SEXP _ANTsRCore_fitBsplineDisplacementField(SEXP r_dimensionalitySEXP, SEXP r_displacementFieldSEXP, SEXP r_displacementFieldWeightImageSEXP, SEXP r_displacementOriginsSEXP, SEXP r_displacementsSEXP, SEXP r_displacementWeightsSEXP, SEXP r_originSEXP, SEXP r_spacingSEXP, SEXP r_sizeSEXP, SEXP r_directionSEXP, SEXP r_numberOfFittingLevelsSEXP, SEXP r_numberOfControlPointsSEXP, SEXP r_splineOrderSEXP, SEXP r_enforceStationaryBoundarySEXP, SEXP r_estimateInverseSEXP, SEXP r_rasterizePointsSEXP) {
+// fitBsplineDisplacementFieldR
+SEXP fitBsplineDisplacementFieldR(SEXP r_dimensionality, SEXP r_displacementField, SEXP r_displacementFieldWeightImage, SEXP r_displacementOrigins, SEXP r_displacements, SEXP r_displacementWeights, SEXP r_origin, SEXP r_spacing, SEXP r_size, SEXP r_direction, SEXP r_numberOfFittingLevels, SEXP r_numberOfControlPoints, SEXP r_splineOrder, SEXP r_enforceStationaryBoundary, SEXP r_estimateInverse, SEXP r_rasterizePoints);
+RcppExport SEXP _ANTsRCore_fitBsplineDisplacementFieldR(SEXP r_dimensionalitySEXP, SEXP r_displacementFieldSEXP, SEXP r_displacementFieldWeightImageSEXP, SEXP r_displacementOriginsSEXP, SEXP r_displacementsSEXP, SEXP r_displacementWeightsSEXP, SEXP r_originSEXP, SEXP r_spacingSEXP, SEXP r_sizeSEXP, SEXP r_directionSEXP, SEXP r_numberOfFittingLevelsSEXP, SEXP r_numberOfControlPointsSEXP, SEXP r_splineOrderSEXP, SEXP r_enforceStationaryBoundarySEXP, SEXP r_estimateInverseSEXP, SEXP r_rasterizePointsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -97,13 +97,13 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< SEXP >::type r_enforceStationaryBoundary(r_enforceStationaryBoundarySEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_estimateInverse(r_estimateInverseSEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_rasterizePoints(r_rasterizePointsSEXP);
-    rcpp_result_gen = Rcpp::wrap(fitBsplineDisplacementField(r_dimensionality, r_displacementField, r_displacementFieldWeightImage, r_displacementOrigins, r_displacements, r_displacementWeights, r_origin, r_spacing, r_size, r_direction, r_numberOfFittingLevels, r_numberOfControlPoints, r_splineOrder, r_enforceStationaryBoundary, r_estimateInverse, r_rasterizePoints));
+    rcpp_result_gen = Rcpp::wrap(fitBsplineDisplacementFieldR(r_dimensionality, r_displacementField, r_displacementFieldWeightImage, r_displacementOrigins, r_displacements, r_displacementWeights, r_origin, r_spacing, r_size, r_direction, r_numberOfFittingLevels, r_numberOfControlPoints, r_splineOrder, r_enforceStationaryBoundary, r_estimateInverse, r_rasterizePoints));
     return rcpp_result_gen;
 END_RCPP
 }
-// fitBsplineObjectToScatteredData
-SEXP fitBsplineObjectToScatteredData(SEXP r_scatteredData, SEXP r_parametricData, SEXP r_dataWeights, SEXP r_parametricDomainOrigin, SEXP r_parametricDomainSpacing, SEXP r_parametricDomainSize, SEXP r_isParametricDimensionClosed, SEXP r_numberOfFittingLevels, SEXP r_numberOfControlPoints, SEXP r_splineOrder);
-RcppExport SEXP _ANTsRCore_fitBsplineObjectToScatteredData(SEXP r_scatteredDataSEXP, SEXP r_parametricDataSEXP, SEXP r_dataWeightsSEXP, SEXP r_parametricDomainOriginSEXP, SEXP r_parametricDomainSpacingSEXP, SEXP r_parametricDomainSizeSEXP, SEXP r_isParametricDimensionClosedSEXP, SEXP r_numberOfFittingLevelsSEXP, SEXP r_numberOfControlPointsSEXP, SEXP r_splineOrderSEXP) {
+// fitBsplineObjectToScatteredDataR
+SEXP fitBsplineObjectToScatteredDataR(SEXP r_scatteredData, SEXP r_parametricData, SEXP r_dataWeights, SEXP r_parametricDomainOrigin, SEXP r_parametricDomainSpacing, SEXP r_parametricDomainSize, SEXP r_isParametricDimensionClosed, SEXP r_numberOfFittingLevels, SEXP r_numberOfControlPoints, SEXP r_splineOrder);
+RcppExport SEXP _ANTsRCore_fitBsplineObjectToScatteredDataR(SEXP r_scatteredDataSEXP, SEXP r_parametricDataSEXP, SEXP r_dataWeightsSEXP, SEXP r_parametricDomainOriginSEXP, SEXP r_parametricDomainSpacingSEXP, SEXP r_parametricDomainSizeSEXP, SEXP r_isParametricDimensionClosedSEXP, SEXP r_numberOfFittingLevelsSEXP, SEXP r_numberOfControlPointsSEXP, SEXP r_splineOrderSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -117,13 +117,13 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< SEXP >::type r_numberOfFittingLevels(r_numberOfFittingLevelsSEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_numberOfControlPoints(r_numberOfControlPointsSEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_splineOrder(r_splineOrderSEXP);
-    rcpp_result_gen = Rcpp::wrap(fitBsplineObjectToScatteredData(r_scatteredData, r_parametricData, r_dataWeights, r_parametricDomainOrigin, r_parametricDomainSpacing, r_parametricDomainSize, r_isParametricDimensionClosed, r_numberOfFittingLevels, r_numberOfControlPoints, r_splineOrder));
+    rcpp_result_gen = Rcpp::wrap(fitBsplineObjectToScatteredDataR(r_scatteredData, r_parametricData, r_dataWeights, r_parametricDomainOrigin, r_parametricDomainSpacing, r_parametricDomainSize, r_isParametricDimensionClosed, r_numberOfFittingLevels, r_numberOfControlPoints, r_splineOrder));
     return rcpp_result_gen;
 END_RCPP
 }
-// fitThinPlateSplineDisplacementField
-SEXP fitThinPlateSplineDisplacementField(SEXP r_dimensionality, SEXP r_displacementOrigins, SEXP r_displacements, SEXP r_origin, SEXP r_spacing, SEXP r_size, SEXP r_direction);
-RcppExport SEXP _ANTsRCore_fitThinPlateSplineDisplacementField(SEXP r_dimensionalitySEXP, SEXP r_displacementOriginsSEXP, SEXP r_displacementsSEXP, SEXP r_originSEXP, SEXP r_spacingSEXP, SEXP r_sizeSEXP, SEXP r_directionSEXP) {
+// fitThinPlateSplineDisplacementFieldR
+SEXP fitThinPlateSplineDisplacementFieldR(SEXP r_dimensionality, SEXP r_displacementOrigins, SEXP r_displacements, SEXP r_origin, SEXP r_spacing, SEXP r_size, SEXP r_direction);
+RcppExport SEXP _ANTsRCore_fitThinPlateSplineDisplacementFieldR(SEXP r_dimensionalitySEXP, SEXP r_displacementOriginsSEXP, SEXP r_displacementsSEXP, SEXP r_originSEXP, SEXP r_spacingSEXP, SEXP r_sizeSEXP, SEXP r_directionSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -134,7 +134,7 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< SEXP >::type r_spacing(r_spacingSEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_size(r_sizeSEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_direction(r_directionSEXP);
-    rcpp_result_gen = Rcpp::wrap(fitThinPlateSplineDisplacementField(r_dimensionality, r_displacementOrigins, r_displacements, r_origin, r_spacing, r_size, r_direction));
+    rcpp_result_gen = Rcpp::wrap(fitThinPlateSplineDisplacementFieldR(r_dimensionality, r_displacementOrigins, r_displacements, r_origin, r_spacing, r_size, r_direction));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -165,9 +165,9 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// integrateVelocityField
-SEXP integrateVelocityField(SEXP r_dimensionality, SEXP r_velocityField, SEXP r_lowerBound, SEXP r_upperBound, SEXP r_numberOfIntegrationSteps);
-RcppExport SEXP _ANTsRCore_integrateVelocityField(SEXP r_dimensionalitySEXP, SEXP r_velocityFieldSEXP, SEXP r_lowerBoundSEXP, SEXP r_upperBoundSEXP, SEXP r_numberOfIntegrationStepsSEXP) {
+// integrateVelocityFieldR
+SEXP integrateVelocityFieldR(SEXP r_dimensionality, SEXP r_velocityField, SEXP r_lowerBound, SEXP r_upperBound, SEXP r_numberOfIntegrationSteps);
+RcppExport SEXP _ANTsRCore_integrateVelocityFieldR(SEXP r_dimensionalitySEXP, SEXP r_velocityFieldSEXP, SEXP r_lowerBoundSEXP, SEXP r_upperBoundSEXP, SEXP r_numberOfIntegrationStepsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -176,13 +176,13 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< SEXP >::type r_lowerBound(r_lowerBoundSEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_upperBound(r_upperBoundSEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_numberOfIntegrationSteps(r_numberOfIntegrationStepsSEXP);
-    rcpp_result_gen = Rcpp::wrap(integrateVelocityField(r_dimensionality, r_velocityField, r_lowerBound, r_upperBound, r_numberOfIntegrationSteps));
+    rcpp_result_gen = Rcpp::wrap(integrateVelocityFieldR(r_dimensionality, r_velocityField, r_lowerBound, r_upperBound, r_numberOfIntegrationSteps));
     return rcpp_result_gen;
 END_RCPP
 }
-// invertDisplacementField
-SEXP invertDisplacementField(SEXP r_dimensionality, SEXP r_displacementField, SEXP r_inverseFieldInitialEstimate, SEXP r_maxNumberOfIterations, SEXP r_meanErrorToleranceThreshold, SEXP r_maxErrorToleranceThreshold, SEXP r_enforceBoundaryCondition);
-RcppExport SEXP _ANTsRCore_invertDisplacementField(SEXP r_dimensionalitySEXP, SEXP r_displacementFieldSEXP, SEXP r_inverseFieldInitialEstimateSEXP, SEXP r_maxNumberOfIterationsSEXP, SEXP r_meanErrorToleranceThresholdSEXP, SEXP r_maxErrorToleranceThresholdSEXP, SEXP r_enforceBoundaryConditionSEXP) {
+// invertDisplacementFieldR
+SEXP invertDisplacementFieldR(SEXP r_dimensionality, SEXP r_displacementField, SEXP r_inverseFieldInitialEstimate, SEXP r_maxNumberOfIterations, SEXP r_meanErrorToleranceThreshold, SEXP r_maxErrorToleranceThreshold, SEXP r_enforceBoundaryCondition);
+RcppExport SEXP _ANTsRCore_invertDisplacementFieldR(SEXP r_dimensionalitySEXP, SEXP r_displacementFieldSEXP, SEXP r_inverseFieldInitialEstimateSEXP, SEXP r_maxNumberOfIterationsSEXP, SEXP r_meanErrorToleranceThresholdSEXP, SEXP r_maxErrorToleranceThresholdSEXP, SEXP r_enforceBoundaryConditionSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -193,7 +193,7 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< SEXP >::type r_meanErrorToleranceThreshold(r_meanErrorToleranceThresholdSEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_maxErrorToleranceThreshold(r_maxErrorToleranceThresholdSEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_enforceBoundaryCondition(r_enforceBoundaryConditionSEXP);
-    rcpp_result_gen = Rcpp::wrap(invertDisplacementField(r_dimensionality, r_displacementField, r_inverseFieldInitialEstimate, r_maxNumberOfIterations, r_meanErrorToleranceThreshold, r_maxErrorToleranceThreshold, r_enforceBoundaryCondition));
+    rcpp_result_gen = Rcpp::wrap(invertDisplacementFieldR(r_dimensionality, r_displacementField, r_inverseFieldInitialEstimate, r_maxNumberOfIterations, r_meanErrorToleranceThreshold, r_maxErrorToleranceThreshold, r_enforceBoundaryCondition));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1391,16 +1391,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// imagesToMatrix
-SEXP imagesToMatrix(SEXP r_fns, SEXP r_mask, SEXP r_n);
-RcppExport SEXP _ANTsRCore_imagesToMatrix(SEXP r_fnsSEXP, SEXP r_maskSEXP, SEXP r_nSEXP) {
+// imagesToMatrixR
+SEXP imagesToMatrixR(SEXP r_fns, SEXP r_mask, SEXP r_n);
+RcppExport SEXP _ANTsRCore_imagesToMatrixR(SEXP r_fnsSEXP, SEXP r_maskSEXP, SEXP r_nSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< SEXP >::type r_fns(r_fnsSEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_mask(r_maskSEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_n(r_nSEXP);
-    rcpp_result_gen = Rcpp::wrap(imagesToMatrix(r_fns, r_mask, r_n));
+    rcpp_result_gen = Rcpp::wrap(imagesToMatrixR(r_fns, r_mask, r_n));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1535,16 +1535,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// reflectionMatrix
-SEXP reflectionMatrix(SEXP r_image, SEXP r_axis, SEXP r_filename);
-RcppExport SEXP _ANTsRCore_reflectionMatrix(SEXP r_imageSEXP, SEXP r_axisSEXP, SEXP r_filenameSEXP) {
+// reflectionMatrixR
+SEXP reflectionMatrixR(SEXP r_image, SEXP r_axis, SEXP r_filename);
+RcppExport SEXP _ANTsRCore_reflectionMatrixR(SEXP r_imageSEXP, SEXP r_axisSEXP, SEXP r_filenameSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< SEXP >::type r_image(r_imageSEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_axis(r_axisSEXP);
     Rcpp::traits::input_parameter< SEXP >::type r_filename(r_filenameSEXP);
-    rcpp_result_gen = Rcpp::wrap(reflectionMatrix(r_image, r_axis, r_filename));
+    rcpp_result_gen = Rcpp::wrap(reflectionMatrixR(r_image, r_axis, r_filename));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1710,13 +1710,13 @@ static const R_CallMethodDef CallEntries[] = {
     {"_ANTsRCore_Atropos", (DL_FUNC) &_ANTsRCore_Atropos, 1},
     {"_ANTsRCore_createJacobianDeterminantImageR", (DL_FUNC) &_ANTsRCore_createJacobianDeterminantImageR, 4},
     {"_ANTsRCore_DenoiseImage", (DL_FUNC) &_ANTsRCore_DenoiseImage, 1},
-    {"_ANTsRCore_fitBsplineDisplacementField", (DL_FUNC) &_ANTsRCore_fitBsplineDisplacementField, 16},
-    {"_ANTsRCore_fitBsplineObjectToScatteredData", (DL_FUNC) &_ANTsRCore_fitBsplineObjectToScatteredData, 10},
-    {"_ANTsRCore_fitThinPlateSplineDisplacementField", (DL_FUNC) &_ANTsRCore_fitThinPlateSplineDisplacementField, 7},
+    {"_ANTsRCore_fitBsplineDisplacementFieldR", (DL_FUNC) &_ANTsRCore_fitBsplineDisplacementFieldR, 16},
+    {"_ANTsRCore_fitBsplineObjectToScatteredDataR", (DL_FUNC) &_ANTsRCore_fitBsplineObjectToScatteredDataR, 10},
+    {"_ANTsRCore_fitThinPlateSplineDisplacementFieldR", (DL_FUNC) &_ANTsRCore_fitThinPlateSplineDisplacementFieldR, 7},
     {"_ANTsRCore_HausdorffDistanceR", (DL_FUNC) &_ANTsRCore_HausdorffDistanceR, 2},
     {"_ANTsRCore_histogramMatchImageR", (DL_FUNC) &_ANTsRCore_histogramMatchImageR, 5},
-    {"_ANTsRCore_integrateVelocityField", (DL_FUNC) &_ANTsRCore_integrateVelocityField, 5},
-    {"_ANTsRCore_invertDisplacementField", (DL_FUNC) &_ANTsRCore_invertDisplacementField, 7},
+    {"_ANTsRCore_integrateVelocityFieldR", (DL_FUNC) &_ANTsRCore_integrateVelocityFieldR, 5},
+    {"_ANTsRCore_invertDisplacementFieldR", (DL_FUNC) &_ANTsRCore_invertDisplacementFieldR, 7},
     {"_ANTsRCore_KellyKapowski", (DL_FUNC) &_ANTsRCore_KellyKapowski, 1},
     {"_ANTsRCore_LabelClustersUniquely", (DL_FUNC) &_ANTsRCore_LabelClustersUniquely, 1},
     {"_ANTsRCore_LabelGeometryMeasures", (DL_FUNC) &_ANTsRCore_LabelGeometryMeasures, 1},
@@ -1814,7 +1814,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_ANTsRCore_iMathInterface", (DL_FUNC) &_ANTsRCore_iMathInterface, 1},
     {"_ANTsRCore_iMathInterface1", (DL_FUNC) &_ANTsRCore_iMathInterface1, 1},
     {"_ANTsRCore_iMathInterface2", (DL_FUNC) &_ANTsRCore_iMathInterface2, 1},
-    {"_ANTsRCore_imagesToMatrix", (DL_FUNC) &_ANTsRCore_imagesToMatrix, 3},
+    {"_ANTsRCore_imagesToMatrixR", (DL_FUNC) &_ANTsRCore_imagesToMatrixR, 3},
     {"_ANTsRCore_invariantImageSimilarity", (DL_FUNC) &_ANTsRCore_invariantImageSimilarity, 12},
     {"_ANTsRCore_itkConvolveImage", (DL_FUNC) &_ANTsRCore_itkConvolveImage, 2},
     {"_ANTsRCore_labelStatsR", (DL_FUNC) &_ANTsRCore_labelStatsR, 2},
@@ -1824,7 +1824,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_ANTsRCore_patchAnalysis", (DL_FUNC) &_ANTsRCore_patchAnalysis, 12},
     {"_ANTsRCore_rcpp_hello_world22", (DL_FUNC) &_ANTsRCore_rcpp_hello_world22, 0},
     {"_ANTsRCore_rcpp_hello_world33", (DL_FUNC) &_ANTsRCore_rcpp_hello_world33, 0},
-    {"_ANTsRCore_reflectionMatrix", (DL_FUNC) &_ANTsRCore_reflectionMatrix, 3},
+    {"_ANTsRCore_reflectionMatrixR", (DL_FUNC) &_ANTsRCore_reflectionMatrixR, 3},
     {"_ANTsRCore_reorientImageR", (DL_FUNC) &_ANTsRCore_reorientImageR, 6},
     {"_ANTsRCore_centerOfMass", (DL_FUNC) &_ANTsRCore_centerOfMass, 1},
     {"_ANTsRCore_sccanX", (DL_FUNC) &_ANTsRCore_sccanX, 1},

--- a/src/antsAffineInitializer.cpp
+++ b/src/antsAffineInitializer.cpp
@@ -6,7 +6,7 @@
 #include "antsr.h"
 
 // [[Rcpp::export]]
-SEXP antsAffineInitializer( SEXP r_args )
+SEXP AntsAffineInitializer( SEXP r_args )
 try
 {
   std::vector< std::string > args = Rcpp::as< std::vector< std::string > >( r_args ) ;

--- a/src/antsApplyTransforms.cpp
+++ b/src/antsApplyTransforms.cpp
@@ -5,7 +5,7 @@
 #include "antsr.h"
 
 // [[Rcpp::export]]
-SEXP antsApplyTransforms( SEXP r_args )
+SEXP AntsApplyTransforms( SEXP r_args )
 try
 {
   std::vector< std::string > args = Rcpp::as< std::vector< std::string > >( r_args ) ;

--- a/src/antsApplyTransformsToPoints.cpp
+++ b/src/antsApplyTransformsToPoints.cpp
@@ -5,7 +5,7 @@
 #include "antsr.h"
 
 // [[Rcpp::export]]
-SEXP antsApplyTransformsToPoints( SEXP r_args )
+SEXP AntsApplyTransformsToPoints( SEXP r_args )
 try
 {
   std::vector< std::string > args = Rcpp::as< std::vector< std::string > >( r_args ) ;

--- a/src/antsImageClone.cpp
+++ b/src/antsImageClone.cpp
@@ -33,7 +33,7 @@ namespace ants
 }
 
 // [[Rcpp::export]]
-SEXP antsImageClone( SEXP r_in_image , SEXP r_out_pixeltype )
+SEXP AntsImageClone( SEXP r_in_image , SEXP r_out_pixeltype )
 {
   if( r_in_image == NULL || r_out_pixeltype == NULL )
     {

--- a/src/antsImageHeaderInfo.cpp
+++ b/src/antsImageHeaderInfo.cpp
@@ -6,7 +6,7 @@
 #include "itkImageFileReader.h"
 
 // [[Rcpp::export]]
-SEXP antsImageHeaderInfo( SEXP r_filename )
+SEXP AntsImageHeaderInfo( SEXP r_filename )
 try
 {
   std::string fname = Rcpp::as<std::string>(r_filename);

--- a/src/antsImageIterator.cpp
+++ b/src/antsImageIterator.cpp
@@ -31,7 +31,7 @@ SEXP antsImageIterator( SEXP r_antsimage )
 
 
 // [[Rcpp::export]]
-SEXP antsImageIterator( SEXP r_antsimage )
+SEXP AntsImageIterator( SEXP r_antsimage )
 {
 try
 {

--- a/src/antsImageRead.cpp
+++ b/src/antsImageRead.cpp
@@ -23,7 +23,7 @@ SEXP antsImageRead( std::string filename, std::string pixeltype, unsigned int co
 
 
 // [[Rcpp::export]]
-SEXP antsImageRead( SEXP r_filename , SEXP r_pixeltype , SEXP r_dimension, SEXP r_components )
+SEXP AntsImageRead( SEXP r_filename , SEXP r_pixeltype , SEXP r_dimension, SEXP r_components )
 {
 try
 {

--- a/src/antsImageStats.cpp
+++ b/src/antsImageStats.cpp
@@ -57,7 +57,7 @@ SEXP antsImageStats( SEXP r_antsimage, SEXP r_mask, SEXP r_narm )
 }
 
 // [[Rcpp::export]]
-SEXP antsImageStats( SEXP r_antsimage, SEXP r_mask, SEXP r_narm ) {
+SEXP AntsImageStats( SEXP r_antsimage, SEXP r_mask, SEXP r_narm ) {
 try
   {
   if( r_antsimage == NULL )

--- a/src/antsImageWrite.cpp
+++ b/src/antsImageWrite.cpp
@@ -68,7 +68,7 @@ namespace ants
 } // namespace ants
 
 // [[Rcpp::export]]
-SEXP antsImageWrite( SEXP r_img , SEXP r_filename, SEXP r_asTensor )
+SEXP AntsImageWrite( SEXP r_img , SEXP r_filename, SEXP r_asTensor )
 {
 try
 {

--- a/src/antsMotionCorr.cpp
+++ b/src/antsMotionCorr.cpp
@@ -6,7 +6,7 @@
 #include "antsr.h"
 
 // [[Rcpp::export]]
-SEXP antsMotionCorr( SEXP r_args )
+SEXP AntsMotionCorr( SEXP r_args )
 try
 {
   std::vector< std::string > args = Rcpp::as< std::vector< std::string > >( r_args ) ;

--- a/src/antsRegistration.cpp
+++ b/src/antsRegistration.cpp
@@ -6,7 +6,7 @@
 #include "antsr.h"
 
 // [[Rcpp::export]]
-SEXP antsRegistration( SEXP r_args )
+SEXP AntsRegistration( SEXP r_args )
 try
 {
   std::vector< std::string > args = Rcpp::as< std::vector< std::string > >( r_args ) ;

--- a/src/cropImage.cpp
+++ b/src/cropImage.cpp
@@ -145,7 +145,7 @@ typename ImageType::Pointer decropImageHelper(
 }
 
 // [[Rcpp::export]]
-SEXP cropImage( SEXP r_in_image1 ,
+SEXP CropImage( SEXP r_in_image1 ,
   SEXP r_in_image2,  SEXP r_label, SEXP r_decrop,
   SEXP r_loind, SEXP r_upind  )
 {
@@ -334,7 +334,7 @@ return extracter->GetOutput();
 }
 
 // [[Rcpp::export]]
-SEXP extractSlice( SEXP r_in_image1,
+SEXP ExtractSlice( SEXP r_in_image1,
   SEXP r_slice, SEXP r_direction, SEXP r_collapseStrategy  )
 {
   if( r_in_image1 == NULL  )

--- a/src/fsl2antsrTransform.cpp
+++ b/src/fsl2antsrTransform.cpp
@@ -152,7 +152,7 @@ SEXP fsl2antsrTransform( SEXP r_matrix, SEXP r_reference, SEXP r_moving, short f
 }
 
 // [[Rcpp::export]]
-SEXP fsl2antsrTransform( SEXP r_matrix, SEXP r_reference, SEXP r_moving, SEXP r_flag )
+SEXP fsl2antsrTransformR( SEXP r_matrix, SEXP r_reference, SEXP r_moving, SEXP r_flag )
 {
 try
 {

--- a/src/imagesToMatrix.cpp
+++ b/src/imagesToMatrix.cpp
@@ -55,7 +55,7 @@ Rcpp::NumericMatrix imagesToMatrixHelper( std::vector< std::string > fns,
 }
 
 // [[Rcpp::export]]
-SEXP imagesToMatrix( SEXP r_fns, SEXP r_mask,
+SEXP imagesToMatrixR( SEXP r_fns, SEXP r_mask,
   SEXP r_n )
 {
   if( r_mask == NULL  )

--- a/src/labelStats.cpp
+++ b/src/labelStats.cpp
@@ -130,7 +130,7 @@ Rcpp::DataFrame labelStatsHelper(
 }
 
 // [[Rcpp::export]]
-SEXP labelStats(SEXP r_image, SEXP r_labelImage)
+SEXP labelStatsR(SEXP r_image, SEXP r_labelImage)
 {
   if( r_image == NULL || r_labelImage == NULL  )
     {

--- a/src/makeImage.cpp
+++ b/src/makeImage.cpp
@@ -47,7 +47,7 @@ SEXP makeImage( Rcpp::NumericVector size, Rcpp::NumericVector spacing,
 }
 
 // [[Rcpp::export]]
-SEXP makeImage( SEXP r_pixeltype, SEXP r_size, SEXP r_spacing, SEXP r_origin, SEXP r_direction, SEXP r_components )
+SEXP makeImageR( SEXP r_pixeltype, SEXP r_size, SEXP r_spacing, SEXP r_origin, SEXP r_direction, SEXP r_components )
 {
 try
 {

--- a/src/mergeChannels.cpp
+++ b/src/mergeChannels.cpp
@@ -48,7 +48,7 @@ SEXP mergeChannels( Rcpp::List imageList )
 }
 
 // [[Rcpp::export]]
-SEXP mergeChannels( SEXP r_imageList )
+SEXP mergeChannelsR( SEXP r_imageList )
 {
 try
 {

--- a/src/reflectionMatrix.cpp
+++ b/src/reflectionMatrix.cpp
@@ -55,7 +55,7 @@ SEXP reflectionMatrix( SEXP r_image, unsigned int axis, std::string filename )
 
 
 // [[Rcpp::export]]
-SEXP reflectionMatrix( SEXP r_image, SEXP r_axis, SEXP r_filename )
+SEXP reflectionMatrixR( SEXP r_image, SEXP r_axis, SEXP r_filename )
 {
 try
 {

--- a/src/reorientImage.cpp
+++ b/src/reorientImage.cpp
@@ -177,7 +177,7 @@ SEXP antsCoMHelper(
 
 
 // [[Rcpp::export]]
-SEXP reorientImage( SEXP r_in_image1, SEXP r_txfn,
+SEXP reorientImageR( SEXP r_in_image1, SEXP r_txfn,
   SEXP r_axis1, SEXP r_axis2, SEXP rrfl, SEXP rscl )
 {
   if( r_in_image1 == NULL  )

--- a/src/smoothImage.cpp
+++ b/src/smoothImage.cpp
@@ -54,7 +54,7 @@ SEXP smoothImageHelper(
 }
 
 // [[Rcpp::export]]
-SEXP smoothImage( SEXP r_inimg,
+SEXP smoothImageR( SEXP r_inimg,
     SEXP r_outimg,
     SEXP r_sigma,
     SEXP sigmaInPhysicalCoordinates,

--- a/src/splitChannels.cpp
+++ b/src/splitChannels.cpp
@@ -54,7 +54,7 @@ SEXP splitChannels( SEXP r_antsimage )
 }
 
 // [[Rcpp::export]]
-SEXP splitChannels( SEXP r_antsimage )
+SEXP splitChannelsR( SEXP r_antsimage )
 {
 try
 {

--- a/src/weingartenImageCurvature.cpp
+++ b/src/weingartenImageCurvature.cpp
@@ -59,7 +59,7 @@ SEXP imagek( SEXP r_antsimage, SEXP r_sigma, SEXP r_opt, SEXP r_labeled )
 
 
 // [[Rcpp::export]]
-SEXP weingartenImageCurvature( SEXP r_antsimage,
+SEXP weingartenImageCurvatureR( SEXP r_antsimage,
   SEXP r_sigma, SEXP r_opt, SEXP r_labeled )
 {
 try


### PR DESCRIPTION
There are some functions named the same thing in ANTsRCore and ANTsR. This is leading to some namespace collisions as people are calling the internal ANTsRCore function instead of the ANTsR function. Most functions in ANTsRCore have some kind of difference from the user-facing ANTsR function already, but some are missing that. This PR adds that for the rest.